### PR TITLE
Add ghc-major-version to Stackage table #88

### DIFF
--- a/Data/GhcLinks.hs
+++ b/Data/GhcLinks.hs
@@ -10,6 +10,7 @@ import qualified Data.Yaml as Yaml
 import Filesystem (readTextFile, isFile)
 
 import Types
+import Model
 
 
 newtype GhcLinks = GhcLinks
@@ -32,8 +33,9 @@ readGhcLinks dir = do
             ]
       hashMap <- flip execStateT HashMap.empty
                $ forM_ opts $ \(arch, ver) -> do
-        let fileName = "ghc-" <> ver <> "-links.yaml"
-        let path = dir
+        let verText = ghcMajorVersionToText ver
+            fileName = "ghc-" <> verText <> "-links.yaml"
+            path = dir
               </> fpFromText (toPathPiece arch)
               </> fpFromText fileName
         whenM (liftIO $ isFile path) $ do

--- a/Handler/UploadStackage.hs
+++ b/Handler/UploadStackage.hs
@@ -139,6 +139,7 @@ putUploadStackageR = do
                         , stackageDesc = "No description provided"
                         , stackageHasHaddocks = False
                         , stackageSlug = baseSlug
+                        , stackageGhcMajorVersion = Nothing -- Assumption: this file is deprecated
                         }
 
                 -- Evil lazy I/O thanks to tar package

--- a/Model.hs
+++ b/Model.hs
@@ -2,10 +2,7 @@ module Model where
 
 import ClassyPrelude.Yesod
 import Database.Persist.Quasi
-import Data.Aeson
-import Data.Hashable (hashUsing)
 import Data.Slug (Slug, SnapSlug)
-import qualified Data.Text as Text
 import Types
 
 -- You can define all of your database entities in the entities file.
@@ -14,28 +11,3 @@ import Types
 -- http://www.yesodweb.com/book/persistent/
 share [mkPersist sqlSettings, mkMigrate "migrateAll"]
     $(persistFileWith lowerCaseSettings "config/models")
-
-
-ghcMajorVersionToText :: GhcMajorVersion -> Text
-ghcMajorVersionToText (GhcMajorVersion major minor)
-  = pack (show major) <> "." <> pack (show minor)
-
-ghcMajorVersionFromText :: Text -> Maybe GhcMajorVersion
-ghcMajorVersionFromText t = case Text.splitOn "." t of
-  [readMay -> Just major, readMay -> Just minor] ->
-    Just $ GhcMajorVersion major minor
-  _ -> Nothing
-
-instance Hashable GhcMajorVersion where
-  hashWithSalt = hashUsing ghcMajorVersionToText
-
-instance Eq GhcMajorVersion where
-  (GhcMajorVersion a b) == (GhcMajorVersion a' b') =
-    a == a' && b == b'
-
-instance FromJSON GhcMajorVersion where
-  parseJSON = withText "GhcMajorVersion" $
-    maybe mzero return . ghcMajorVersionFromText
-
-instance ToJSON GhcMajorVersion where
-  toJSON = toJSON . ghcMajorVersionToText

--- a/Model.hs
+++ b/Model.hs
@@ -2,7 +2,10 @@ module Model where
 
 import ClassyPrelude.Yesod
 import Database.Persist.Quasi
+import Data.Aeson
+import Data.Hashable (hashUsing)
 import Data.Slug (Slug, SnapSlug)
+import qualified Data.Text as Text
 import Types
 
 -- You can define all of your database entities in the entities file.
@@ -11,3 +14,28 @@ import Types
 -- http://www.yesodweb.com/book/persistent/
 share [mkPersist sqlSettings, mkMigrate "migrateAll"]
     $(persistFileWith lowerCaseSettings "config/models")
+
+
+ghcMajorVersionToText :: GhcMajorVersion -> Text
+ghcMajorVersionToText (GhcMajorVersion major minor)
+  = pack (show major) <> "." <> pack (show minor)
+
+ghcMajorVersionFromText :: Text -> Maybe GhcMajorVersion
+ghcMajorVersionFromText t = case Text.splitOn "." t of
+  [readMay -> Just major, readMay -> Just minor] ->
+    Just $ GhcMajorVersion major minor
+  _ -> Nothing
+
+instance Hashable GhcMajorVersion where
+  hashWithSalt = hashUsing ghcMajorVersionToText
+
+instance Eq GhcMajorVersion where
+  (GhcMajorVersion a b) == (GhcMajorVersion a' b') =
+    a == a' && b == b'
+
+instance FromJSON GhcMajorVersion where
+  parseJSON = withText "GhcMajorVersion" $
+    maybe mzero return . ghcMajorVersionFromText
+
+instance ToJSON GhcMajorVersion where
+  toJSON = toJSON . ghcMajorVersionToText

--- a/Types.hs
+++ b/Types.hs
@@ -118,7 +118,6 @@ instance PathPiece StackageExecutable where
     fromPathPiece "stackage-setup.exe" = Just StackageWindowsExecutable
     fromPathPiece _ = Nothing
 
-type GhcMajorVersion = Text
 
 data SupportedArch
     = Win32

--- a/config/models
+++ b/config/models
@@ -23,6 +23,7 @@ Stackage
     title Text
     desc Text
     hasHaddocks Bool default=false
+    ghcMajorVersion GhcMajorVersion Maybe
     UniqueStackage ident
     UniqueSnapshot slug
 
@@ -131,3 +132,8 @@ Suggested
 UploadProgress
     message Text
     dest Text Maybe
+
+GhcMajorVersion
+    major Int
+    minor Int
+    UniqueGhcMajorVersion major minor

--- a/config/models
+++ b/config/models
@@ -132,8 +132,3 @@ Suggested
 UploadProgress
     message Text
     dest Text Maybe
-
-GhcMajorVersion
-    major Int
-    minor Int
-    UniqueGhcMajorVersion major minor


### PR DESCRIPTION
Made this as a PR because I wanted a code review before merging into master.

I added an optional field to Stackage called GhcMajorVersion, which expresses the intent that the given snapshot should be used with the given major version of ghc.