### PR TITLE
Query database to get the preceding SnapName

### DIFF
--- a/Handler/StackageHome.hs
+++ b/Handler/StackageHome.hs
@@ -11,13 +11,13 @@ import qualified Data.HashMap.Strict as HashMap
 import Data.These
 import Data.Time (FormatTime)
 import Stackage.Database
-import Stackage.Database.Types (isLts, previousSnapName)
+import Stackage.Database.Types (isLts)
 import Stackage.Snapshot.Diff
 
 getStackageHomeR :: SnapName -> Handler Html
 getStackageHomeR name = do
     Entity sid snapshot <- lookupSnapshot name >>= maybe notFound return
-    snapNames <- map (snapshotName . entityVal) . snd <$> getSnapshots 0 0
+    previousSnapName <- fromMaybe name . map snd <$> snapshotBefore (snapshotName snapshot)
     let hoogleForm =
             let queryText = "" :: Text
                 exact = False

--- a/Stackage/Database.hs
+++ b/Stackage/Database.hs
@@ -8,6 +8,7 @@ module Stackage.Database
     , newestLTSMajor
     , ltsMajorVersions
     , newestNightly
+    , snapshotBefore
     , nightlyBefore
     , ltsBefore
     , lookupSnapshot
@@ -427,6 +428,11 @@ ltsMajorVersions =
 newestNightly :: GetStackageDatabase m => m (Maybe Day)
 newestNightly =
     run $ liftM (fmap $ nightlyDay . entityVal) $ selectFirst [] [Desc NightlyDay]
+
+-- | Get the snapshot which precedes the given one with respect to it's branch (nightly/lts)
+snapshotBefore :: GetStackageDatabase m => SnapName -> m (Maybe (SnapshotId, SnapName))
+snapshotBefore (SNLts x y)     = ltsBefore x y
+snapshotBefore (SNNightly day) = nightlyBefore day
 
 nightlyBefore :: GetStackageDatabase m => Day -> m (Maybe (SnapshotId, SnapName))
 nightlyBefore day = do

--- a/Stackage/Database/Types.hs
+++ b/Stackage/Database/Types.hs
@@ -2,7 +2,6 @@ module Stackage.Database.Types
     ( SnapName (..)
     , isLts
     , isNightly
-    , previousSnapName
     ) where
 
 import ClassyPrelude.Conduit
@@ -22,10 +21,6 @@ isLts SNNightly{} = False
 isNightly :: SnapName -> Bool
 isNightly SNLts{}     = False
 isNightly SNNightly{} = True
-
-previousSnapName :: [SnapName] -> SnapName -> SnapName
-previousSnapName ns n =
-  fromMaybe n $ maximumMay $ filter (< n) $ filter ((isLts n ==) . isLts) ns
 
 instance PersistField SnapName where
     toPersistValue = toPersistValue . toPathPiece

--- a/templates/stackage-home.hamlet
+++ b/templates/stackage-home.hamlet
@@ -6,7 +6,7 @@ $newline never
         Published on #{yearMonthDay (snapshotCreated snapshot)}
         <span .separator>
         <span>
-            <a href=@{StackageDiffR (previousSnapName snapNames name) name}>View changes
+            <a href=@{StackageDiffR previousSnapName name}>View changes
         <span .separator>
         <span>
             stack #


### PR DESCRIPTION
That's much better than what I did before. Didn't really now about `ltsBefore`/`nightlyBefore`