### PR TITLE
Badges

### DIFF
--- a/config/routes
+++ b/config/routes
@@ -30,6 +30,7 @@
 /haddock/#SnapName/*Texts HaddockR GET
 /package/#PackageName PackageR GET
 /package/#PackageName/snapshots PackageSnapshotsR GET
+/package/#PackageName/badge/#SnapshotBranch PackageBadgeR GET
 /package PackageListR GET
 
 /authors AuthorsR GET

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,4 @@
 resolver: lts-3.8
 extra-deps:
     - these-0.6.1.0
+    - barrier-0.1.0

--- a/stackage-server.cabal
+++ b/stackage-server.cabal
@@ -92,6 +92,7 @@ library
                     base                          >= 4.8         &&   < 4.9
                   , aeson                         >= 0.8         &&   < 0.9
                   , aws                           >= 0.12        &&   < 0.13
+                  , barrier                       >= 0.1         &&   < 0.2
                   , base16-bytestring             >= 0.1         &&   < 0.2
                   , blaze-markup                  >= 0.7         &&   < 0.8
                   , byteable                      >= 0.1         &&   < 0.2


### PR DESCRIPTION
The feature is outlined in #109. 
At the moment it works like this:

- `/package/containers/badge/lts-3` -> ![](https://img.shields.io/badge/stackage_lts--3-0.5.6.2-brightgreen.svg)
- `/package/containers/badge/nightly` -> ![](https://img.shields.io/badge/stackage_nightly-0.5.6.3-brightgreen.svg)
- `/package/these/badge/lts-3` -> ![](https://img.shields.io/badge/stackage_lts--3-not_available-red.svg)

Please share your suggestions on how it can be improved.

Not ready to be merged yet (I am doing some larger scale refactoring in another branch, which should simplify the code a little).

Also, I think it would worth to document that feature, so that it's easy to find the answer to "How to make a stackage badge". at the moment the best practice is something like:

```html
    <a href="http://stackage.org/lts-3/package/packagename">
        <img src="http://stackage.org/package/packagename/badge/lts-3"
             alt="packagename on Stackage">
    </a>
```
What would be a good place to put these instructions.