### PR TITLE
StackageBranch

### DIFF
--- a/Handler/Feed.hs
+++ b/Handler/Feed.hs
@@ -11,10 +11,13 @@ import qualified Data.HashMap.Strict as HashMap
 import Text.Blaze (text)
 
 getFeedR :: Handler TypedContent
-getFeedR = mkFeed Nothing . snd =<< getSnapshots 20 0
+getFeedR = getBranchFeed Nothing
 
 getBranchFeedR :: StackageBranch -> Handler TypedContent
-getBranchFeedR branch = mkFeed (Just branch) . snd =<< getBranchSnapshots branch 20 0
+getBranchFeedR = getBranchFeed . Just
+
+getBranchFeed :: Maybe StackageBranch -> Handler TypedContent
+getBranchFeed mBranch = mkFeed mBranch =<< getSnapshots mBranch 20 0
 
 mkFeed :: Maybe StackageBranch -> [Entity Snapshot] -> Handler TypedContent
 mkFeed _ [] = notFound

--- a/Handler/Feed.hs
+++ b/Handler/Feed.hs
@@ -13,13 +13,13 @@ import Text.Blaze (text)
 getFeedR :: Handler TypedContent
 getFeedR = getBranchFeed Nothing
 
-getBranchFeedR :: StackageBranch -> Handler TypedContent
+getBranchFeedR :: SnapshotBranch -> Handler TypedContent
 getBranchFeedR = getBranchFeed . Just
 
-getBranchFeed :: Maybe StackageBranch -> Handler TypedContent
+getBranchFeed :: Maybe SnapshotBranch -> Handler TypedContent
 getBranchFeed mBranch = mkFeed mBranch =<< getSnapshots mBranch 20 0
 
-mkFeed :: Maybe StackageBranch -> [Entity Snapshot] -> Handler TypedContent
+mkFeed :: Maybe SnapshotBranch -> [Entity Snapshot] -> Handler TypedContent
 mkFeed _ [] = notFound
 mkFeed mBranch snaps = do
     entries <- forM snaps $ \(Entity snapid snap) -> do

--- a/Handler/OldLinks.hs
+++ b/Handler/OldLinks.hs
@@ -1,5 +1,5 @@
 module Handler.OldLinks
-    ( getOldStackageBranchR
+    ( getOldSnapshotBranchR
     , getOldSnapshotR
     ) where
 
@@ -26,8 +26,8 @@ redirectWithQueryText url = do
     req <- waiRequest
     redirect $ url ++ decodeUtf8 (rawQueryString req)
 
-getOldStackageBranchR :: StackageBranch -> [Text] -> Handler ()
-getOldStackageBranchR LtsBranch pieces = do
+getOldSnapshotBranchR :: SnapshotBranch -> [Text] -> Handler ()
+getOldSnapshotBranchR LtsBranch pieces = do
     (x, y, pieces') <- case pieces of
         t:ts | Just suffix <- parseLtsSuffix t -> do
             (x, y) <- case suffix of
@@ -42,12 +42,12 @@ getOldStackageBranchR LtsBranch pieces = do
     let name = concat ["lts-", tshow x, ".", tshow y]
     redirectWithQueryText $ concatMap (cons '/') $ name : pieces'
 
-getOldStackageBranchR (LtsMajorBranch x) pieces = do
+getOldSnapshotBranchR (LtsMajorBranch x) pieces = do
     y <- newestLTSMajor x >>= maybe notFound return
     let name = concat ["lts-", tshow x, ".", tshow y]
     redirectWithQueryText $ concatMap (cons '/') $ name : pieces
 
-getOldStackageBranchR NightlyBranch pieces = do
+getOldSnapshotBranchR NightlyBranch pieces = do
     (day, pieces') <- case pieces of
         t:ts | Just day <- fromPathPiece t -> return (day, ts)
         _ -> do

--- a/Handler/OldLinks.hs
+++ b/Handler/OldLinks.hs
@@ -1,7 +1,5 @@
 module Handler.OldLinks
-    ( getOldLtsR
-    , getOldLtsMajorR
-    , getOldNightlyR
+    ( getOldStackageBranchR
     , getOldSnapshotR
     ) where
 
@@ -28,8 +26,8 @@ redirectWithQueryText url = do
     req <- waiRequest
     redirect $ url ++ decodeUtf8 (rawQueryString req)
 
-getOldLtsR :: [Text] -> Handler ()
-getOldLtsR pieces = do
+getOldStackageBranchR :: StackageBranch -> [Text] -> Handler ()
+getOldStackageBranchR LtsBranch pieces = do
     (x, y, pieces') <- case pieces of
         t:ts | Just suffix <- parseLtsSuffix t -> do
             (x, y) <- case suffix of
@@ -44,14 +42,12 @@ getOldLtsR pieces = do
     let name = concat ["lts-", tshow x, ".", tshow y]
     redirectWithQueryText $ concatMap (cons '/') $ name : pieces'
 
-getOldLtsMajorR :: LtsMajor -> [Text] -> Handler ()
-getOldLtsMajorR (LtsMajor x) pieces = do
+getOldStackageBranchR (LtsMajorBranch x) pieces = do
     y <- newestLTSMajor x >>= maybe notFound return
     let name = concat ["lts-", tshow x, ".", tshow y]
     redirectWithQueryText $ concatMap (cons '/') $ name : pieces
 
-getOldNightlyR :: [Text] -> Handler ()
-getOldNightlyR pieces = do
+getOldStackageBranchR NightlyBranch pieces = do
     (day, pieces') <- case pieces of
         t:ts | Just day <- fromPathPiece t -> return (day, ts)
         _ -> do

--- a/Handler/Sitemap.hs
+++ b/Handler/Sitemap.hs
@@ -12,8 +12,6 @@ getSitemapR = sitemap $ do
     priority 1.0 $ HomeR
 
     priority 0.9 $ OldStackageBranchR LtsBranch []
-    -- TODO: uncomment when this is presentable
-    --priority 0.9 $ DownloadR
     priority 0.8 $ OldStackageBranchR NightlyBranch []
 
     priority 0.7 $ AllSnapshotsR

--- a/Handler/Sitemap.hs
+++ b/Handler/Sitemap.hs
@@ -11,8 +11,8 @@ getSitemapR :: Handler TypedContent
 getSitemapR = sitemap $ do
     priority 1.0 $ HomeR
 
-    priority 0.9 $ OldStackageBranchR LtsBranch []
-    priority 0.8 $ OldStackageBranchR NightlyBranch []
+    priority 0.9 $ OldSnapshotBranchR LtsBranch []
+    priority 0.8 $ OldSnapshotBranchR NightlyBranch []
 
     priority 0.7 $ AllSnapshotsR
     priority 0.7 $ PackageListR

--- a/Handler/Sitemap.hs
+++ b/Handler/Sitemap.hs
@@ -11,10 +11,10 @@ getSitemapR :: Handler TypedContent
 getSitemapR = sitemap $ do
     priority 1.0 $ HomeR
 
-    priority 0.9 $ OldLtsR []
+    priority 0.9 $ OldStackageBranchR LtsBranch []
     -- TODO: uncomment when this is presentable
     --priority 0.9 $ DownloadR
-    priority 0.8 $ OldNightlyR []
+    priority 0.8 $ OldStackageBranchR NightlyBranch []
 
     priority 0.7 $ AllSnapshotsR
     priority 0.7 $ PackageListR

--- a/Handler/Snapshots.hs
+++ b/Handler/Snapshots.hs
@@ -24,9 +24,10 @@ getAllSnapshotsR = do
     currentPageMay <- lookupGetParam "page"
     let currentPage :: Int
         currentPage = fromMaybe 1 (currentPageMay >>= readMay)
-    (totalCount, map entityVal -> snapshots) <- getSnapshots
-        snapshotsPerPage
-        ((fromIntegral currentPage - 1) * snapshotsPerPage)
+    totalCount <- countSnapshots Nothing
+    (map entityVal -> snapshots) <-
+        getSnapshots Nothing snapshotsPerPage
+                             ((fromIntegral currentPage - 1) * snapshotsPerPage)
     let groups = groupUp now' snapshots
 
     let isFirstPage = currentPage == 1

--- a/Handler/StackageHome.hs
+++ b/Handler/StackageHome.hs
@@ -32,7 +32,7 @@ getStackageDiffR :: SnapName -> SnapName -> Handler Html
 getStackageDiffR name1 name2 = do
     Entity sid1 _ <- lookupSnapshot name1 >>= maybe notFound return
     Entity sid2 _ <- lookupSnapshot name2 >>= maybe notFound return
-    snapNames <- map (snapshotName . entityVal) . snd <$> getSnapshots 0 0
+    (map (snapshotName . entityVal) -> snapNames) <- getSnapshots Nothing 0 0
     let (ltsSnaps, nightlySnaps) = partition isLts $ reverse $ sort snapNames
     snapDiff <- getSnapshotDiff sid1 sid2
     defaultLayout $ do

--- a/Stackage/Database.hs
+++ b/Stackage/Database.hs
@@ -34,10 +34,7 @@ module Stackage.Database
     , prettyNameShort
     , getSnapshotsForPackage
     , getSnapshots
-    , getLtsSnapshots
-    , getLtsMajorSnapshots
-    , getNightlySnapshots
-    , getBranchSnapshots
+    , countSnapshots
     , currentSchema
     , last5Lts5Nightly
     , snapshotsJSON
@@ -666,73 +663,44 @@ getSnapshotsForPackage pname = run $ do
             Nothing -> Nothing
             Just s -> Just (s, snapshotPackageVersion sp)
 
-getSnapshots
-    :: GetStackageDatabase m
-    => Int -- ^ limit
-    -> Int -- ^ offset
-    -> m (Int, [Entity Snapshot])
-getSnapshots l o = run $ (,)
-    <$> count ([] :: [Filter Snapshot])
-    <*> selectList
-        []
-        [LimitTo l, OffsetBy o, Desc SnapshotCreated]
+-- | Count snapshots that belong to a specific StackageBranch
+countSnapshots :: (GetStackageDatabase m) => Maybe StackageBranch -> m Int
+countSnapshots Nothing                   = run $ count ([] :: [Filter Snapshot])
+countSnapshots (Just NightlyBranch)      = run $ count ([] :: [Filter Nightly])
+countSnapshots (Just LtsBranch)          = run $ count ([] :: [Filter Lts])
+countSnapshots (Just (LtsMajorBranch x)) = run $ count [LtsMajor ==. x]
 
-getBranchSnapshots :: GetStackageDatabase m
-                   => StackageBranch
-                   -> Int -- ^ limit
-                   -> Int -- ^ offset
-                   -> m (Int, [Entity Snapshot])
-getBranchSnapshots NightlyBranch = getNightlySnapshots
-getBranchSnapshots LtsBranch     = getLtsSnapshots
-getBranchSnapshots (LtsMajorBranch x) = getLtsMajorSnapshots x
-
-getLtsSnapshots :: GetStackageDatabase m
-                => Int -- ^ limit
-                -> Int -- ^ offset
-                -> m (Int, [Entity Snapshot])
-getLtsSnapshots l o = run $ do
-    ltsCount <- count ([] :: [Filter Lts])
-    snapshots <- E.select $ E.from $
-        \(lts `E.InnerJoin` snapshot) -> do
+-- | Get snapshots that belong to a specific StackageBranch
+getSnapshots :: (GetStackageDatabase m)
+             => Maybe StackageBranch
+             -> Int -- ^ limit
+             -> Int -- ^ offset
+             -> m [Entity Snapshot]
+getSnapshots mBranch l o = run $ case mBranch of
+    Nothing -> selectList [] [LimitTo l, OffsetBy o, Desc SnapshotCreated]
+    Just NightlyBranch ->
+        E.select $ E.from $ \(nightly `E.InnerJoin` snapshot) -> do
+            E.on $ nightly E.^. NightlySnap E.==. snapshot E.^. SnapshotId
+            E.orderBy [E.desc (nightly E.^. NightlyDay)]
+            E.limit $ fromIntegral l
+            E.offset $ fromIntegral o
+            pure snapshot
+    Just LtsBranch -> do
+        E.select $ E.from $ \(lts `E.InnerJoin` snapshot) -> do
             E.on $ lts E.^. LtsSnap E.==. snapshot E.^. SnapshotId
             E.orderBy [ E.desc (lts E.^. LtsMajor)
                       , E.desc (lts E.^. LtsMinor) ]
             E.limit $ fromIntegral l
             E.offset $ fromIntegral o
-            return snapshot
-    return (ltsCount, snapshots)
-
-getLtsMajorSnapshots :: GetStackageDatabase m
-                => Int -- ^ Major version
-                -> Int -- ^ limit
-                -> Int -- ^ offset
-                -> m (Int, [Entity Snapshot])
-getLtsMajorSnapshots v l o = run $ do
-    ltsCount <- count ([] :: [Filter Lts])
-    snapshots <- E.select $ E.from $
-        \(lts `E.InnerJoin` snapshot) -> do
+            pure snapshot
+    Just (LtsMajorBranch v) -> do
+        E.select $ E.from $ \(lts `E.InnerJoin` snapshot) -> do
             E.on $ lts E.^. LtsSnap E.==. snapshot E.^. SnapshotId
             E.orderBy [E.desc (lts E.^. LtsMinor)]
             E.where_ ((lts E.^. LtsMajor) E.==. (E.val v))
             E.limit $ fromIntegral l
             E.offset $ fromIntegral o
-            return snapshot
-    return (ltsCount, snapshots)
-
-getNightlySnapshots :: GetStackageDatabase m
-                => Int -- ^ limit
-                -> Int -- ^ offset
-                -> m (Int, [Entity Snapshot])
-getNightlySnapshots l o = run $ do
-    nightlyCount <- count ([] :: [Filter Nightly])
-    snapshots <- E.select $ E.from $
-        \(nightly `E.InnerJoin` snapshot) -> do
-            E.on $ nightly E.^. NightlySnap E.==. snapshot E.^. SnapshotId
-            E.orderBy [E.desc (nightly E.^. NightlyDay)]
-            E.limit $ fromIntegral l
-            E.offset $ fromIntegral o
-            return snapshot
-    return (nightlyCount, snapshots)
+            pure snapshot
 
 last5Lts5Nightly :: GetStackageDatabase m => m [SnapName]
 last5Lts5Nightly = run $ do

--- a/Stackage/Database.hs
+++ b/Stackage/Database.hs
@@ -69,7 +69,7 @@ import System.IO.Temp
 import qualified Database.Esqueleto as E
 import Data.Yaml (decode)
 import qualified Data.Aeson as A
-import Types (StackageBranch(..))
+import Types (SnapshotBranch(..))
 
 currentSchema :: Int
 currentSchema = 1
@@ -663,16 +663,16 @@ getSnapshotsForPackage pname = run $ do
             Nothing -> Nothing
             Just s -> Just (s, snapshotPackageVersion sp)
 
--- | Count snapshots that belong to a specific StackageBranch
-countSnapshots :: (GetStackageDatabase m) => Maybe StackageBranch -> m Int
+-- | Count snapshots that belong to a specific SnapshotBranch
+countSnapshots :: (GetStackageDatabase m) => Maybe SnapshotBranch -> m Int
 countSnapshots Nothing                   = run $ count ([] :: [Filter Snapshot])
 countSnapshots (Just NightlyBranch)      = run $ count ([] :: [Filter Nightly])
 countSnapshots (Just LtsBranch)          = run $ count ([] :: [Filter Lts])
 countSnapshots (Just (LtsMajorBranch x)) = run $ count [LtsMajor ==. x]
 
--- | Get snapshots that belong to a specific StackageBranch
+-- | Get snapshots that belong to a specific SnapshotBranch
 getSnapshots :: (GetStackageDatabase m)
-             => Maybe StackageBranch
+             => Maybe SnapshotBranch
              -> Int -- ^ limit
              -> Int -- ^ offset
              -> m [Entity Snapshot]

--- a/Stackage/Database.hs
+++ b/Stackage/Database.hs
@@ -37,6 +37,7 @@ module Stackage.Database
     , getLtsSnapshots
     , getLtsMajorSnapshots
     , getNightlySnapshots
+    , getBranchSnapshots
     , currentSchema
     , last5Lts5Nightly
     , snapshotsJSON
@@ -71,6 +72,7 @@ import System.IO.Temp
 import qualified Database.Esqueleto as E
 import Data.Yaml (decode)
 import qualified Data.Aeson as A
+import Types (StackageBranch(..))
 
 currentSchema :: Int
 currentSchema = 1
@@ -674,6 +676,15 @@ getSnapshots l o = run $ (,)
     <*> selectList
         []
         [LimitTo l, OffsetBy o, Desc SnapshotCreated]
+
+getBranchSnapshots :: GetStackageDatabase m
+                   => StackageBranch
+                   -> Int -- ^ limit
+                   -> Int -- ^ offset
+                   -> m (Int, [Entity Snapshot])
+getBranchSnapshots NightlyBranch = getNightlySnapshots
+getBranchSnapshots LtsBranch     = getLtsSnapshots
+getBranchSnapshots (LtsMajorBranch x) = getLtsMajorSnapshots x
 
 getLtsSnapshots :: GetStackageDatabase m
                 => Int -- ^ limit

--- a/Types.hs
+++ b/Types.hs
@@ -11,11 +11,11 @@ import qualified Data.Text.Lazy.Builder as Builder
 import qualified Data.Text.Lazy as LText
 import qualified Data.Text.Read as Reader
 
-data StackageBranch = LtsMajorBranch Int
+data SnapshotBranch = LtsMajorBranch Int
                     | LtsBranch
                     | NightlyBranch
                     deriving (Eq, Read, Show)
-instance PathPiece StackageBranch where
+instance PathPiece SnapshotBranch where
     toPathPiece NightlyBranch = "nightly"
     toPathPiece LtsBranch     = "lts"
     toPathPiece (LtsMajorBranch x) = "lts-" ++ tshow x

--- a/Types.hs
+++ b/Types.hs
@@ -11,15 +11,6 @@ import qualified Data.Text.Lazy.Builder as Builder
 import qualified Data.Text.Lazy as LText
 import qualified Data.Text.Read as Reader
 
-newtype LtsMajor = LtsMajor Int
-    deriving (Eq, Read, Show)
-instance PathPiece LtsMajor where
-    toPathPiece (LtsMajor x) = "lts-" ++ tshow x
-    fromPathPiece t0 = do
-        t1 <- stripPrefix "lts-" t0
-        Right (x, "") <- Just $ Reader.decimal t1
-        Just $ LtsMajor x
-
 data StackageBranch = LtsMajorBranch Int
                     | LtsBranch
                     | NightlyBranch
@@ -27,11 +18,14 @@ data StackageBranch = LtsMajorBranch Int
 instance PathPiece StackageBranch where
     toPathPiece NightlyBranch = "nightly"
     toPathPiece LtsBranch     = "lts"
-    toPathPiece (LtsMajorBranch x) = toPathPiece $ LtsMajor x
+    toPathPiece (LtsMajorBranch x) = "lts-" ++ tshow x
 
     fromPathPiece "nightly" = Just NightlyBranch
-    fromPathPiece "lts"     = Just LtsBranch
-    fromPathPiece x         = (\(LtsMajor x') -> LtsMajorBranch x') <$> fromPathPiece x
+    fromPathPiece "lts" = Just LtsBranch
+    fromPathPiece t0 = do
+        t1 <- stripPrefix "lts-" t0
+        Right (x, "") <- Just $ Reader.decimal t1
+        Just $ LtsMajorBranch x
 
 newtype PackageName = PackageName { unPackageName :: Text }
     deriving (Show, Read, Typeable, Eq, Ord, Hashable, PathPiece, ToMarkup, PersistField, IsString)

--- a/Types.hs
+++ b/Types.hs
@@ -20,6 +20,19 @@ instance PathPiece LtsMajor where
         Right (x, "") <- Just $ Reader.decimal t1
         Just $ LtsMajor x
 
+data StackageBranch = LtsMajorBranch Int
+                    | LtsBranch
+                    | NightlyBranch
+                    deriving (Eq, Read, Show)
+instance PathPiece StackageBranch where
+    toPathPiece NightlyBranch = "nightly"
+    toPathPiece LtsBranch     = "lts"
+    toPathPiece (LtsMajorBranch x) = toPathPiece $ LtsMajor x
+
+    fromPathPiece "nightly" = Just NightlyBranch
+    fromPathPiece "lts"     = Just LtsBranch
+    fromPathPiece x         = (\(LtsMajor x') -> LtsMajorBranch x') <$> fromPathPiece x
+
 newtype PackageName = PackageName { unPackageName :: Text }
     deriving (Show, Read, Typeable, Eq, Ord, Hashable, PathPiece, ToMarkup, PersistField, IsString)
 instance PersistFieldSql PackageName where

--- a/config/routes
+++ b/config/routes
@@ -47,9 +47,7 @@
 /download/#SupportedArch/#Text DownloadGhcLinksR GET
 
 /feed FeedR GET
-!/feed/#LtsMajor LtsMajorFeedR GET
-/feed/lts LtsFeedR GET
-/feed/nightly NightlyFeedR GET
+/feed/#StackageBranch BranchFeedR GET
 
 /stack DownloadStackListR GET
 /stack/#Text DownloadStackR GET

--- a/config/routes
+++ b/config/routes
@@ -1,4 +1,4 @@
-!/#LtsMajor/*Texts OldLtsMajorR GET
+!/#StackageBranch/*Texts OldStackageBranchR GET
 
 /static StaticR Static getStatic
 /reload WebsiteContentR GitRepo-WebsiteContent websiteContent
@@ -31,9 +31,6 @@
 /package/#PackageName PackageR GET
 /package/#PackageName/snapshots PackageSnapshotsR GET
 /package PackageListR GET
-
-/lts/*Texts OldLtsR GET
-/nightly/*Texts OldNightlyR GET
 
 /authors AuthorsR GET
 /install InstallR GET

--- a/config/routes
+++ b/config/routes
@@ -1,4 +1,4 @@
-!/#StackageBranch/*Texts OldStackageBranchR GET
+!/#SnapshotBranch/*Texts OldSnapshotBranchR GET
 
 /static StaticR Static getStatic
 /reload WebsiteContentR GitRepo-WebsiteContent websiteContent
@@ -44,7 +44,7 @@
 /download/#SupportedArch/#Text DownloadGhcLinksR GET
 
 /feed FeedR GET
-/feed/#StackageBranch BranchFeedR GET
+/feed/#SnapshotBranch BranchFeedR GET
 
 /stack DownloadStackListR GET
 /stack/#Text DownloadStackR GET


### PR DESCRIPTION
I noticed that in some places we want to accept the input of sum-type:

```haskell
-- | There might be a better name for that type, suggestions are very welcome
data StackageBranch
  = NightlyBranch      -- e.g /feed/nightly
  | LtsBranch          -- e.g /feed/lts
  | LtsMajorBranch Int -- e.g /feed/lts-3

-- /feed/#StackageBranch BranchFeedR GET

getBranchFeedR :: StackageBranch -> Handler
```

instead of that we have:

```haskell
data LtsMajor = LtsMajor Int

-- !/feed/#LtsMajor LtsMajorFeed GET
-- /feed/nightly LtsNightlyFeedR GET
-- /feed/lts LtsFeedR GET

getLtsMajorFeedR :: LtsMajor -> Handler
getNightlyFeedR :: Handler
getLtsFeedR :: Handler
```

This mostly applies to some handlers and functions in `Stackage.Database`.

So, I removed `LtsMajor` and added `StackageBranch`, and most other changes just follow that up.

In a few places `Maybe StackageBranch` is used and `Nothing` corresponds to all snapshots. Makes sense in function like: `getSnapshots :: Maybe StackageBranch -> _`