### PR TITLE
Set Cache-Control header on badges

### DIFF
--- a/Handler/Package.hs
+++ b/Handler/Package.hs
@@ -27,6 +27,7 @@ getPackageR = packagePage Nothing
 
 getPackageBadgeR :: PackageName -> SnapshotBranch -> Handler TypedContent
 getPackageBadgeR pname branch = do
+    cacheSeconds (3 * 60 * 60)
     snapName     <- maybe notFound pure =<< newestSnapshot branch
     Entity sid _ <- maybe notFound pure =<< lookupSnapshot snapName
     mVersion <- do mSnapPackage <- lookupSnapshotPackage sid (unPackageName pname)


### PR DESCRIPTION
Since [github proxies external resources](https://github.com/blog/743-sidejack-prevention-phase-3-ssl-proxied-assets) we need to indicate that our badges are supposed to be changing.

From a brief study of https://github.com/atmos/camo it seems that unless we set something sensible in 'Cache-Control', the browser would be told to cache an image for a pretty long time.

https://github.com/atmos/camo/blob/da97a43fc385c24abded595b3f278802eb23586b/server.coffee#L103


Related: https://github.com/github/markup/issues/224