### PR TITLE
improvements to package pages

### DIFF
--- a/Handler/Package.hs
+++ b/Handler/Package.hs
@@ -16,7 +16,7 @@ import qualified Data.Text.Lazy as LT
 import           Distribution.Package.ModuleForest
 import           Graphics.Badge.Barrier
 import           Control.Lens
-import           Import
+import           Import hiding (empty)
 import qualified Text.Blaze.Html.Renderer.Text as LT
 import           Text.Email.Validate
 import           Stackage.Database

--- a/Handler/Package.hs
+++ b/Handler/Package.hs
@@ -7,6 +7,7 @@ module Handler.Package
     , getPackageSnapshotsR
     , packagePage
     , getPackageBadgeR
+    , renderNoPackages
     ) where
 
 import           Data.Char
@@ -226,3 +227,7 @@ getPackageSnapshotsR pn =
            $(combineStylesheets 'StaticR
                                 [css_font_awesome_min_css])
            $(widgetFile "package-snapshots"))
+
+renderNoPackages :: Int -> Text
+renderNoPackages n =
+  T.pack $ show n ++ " package" ++ (if n == 1 then "" else "s")

--- a/Handler/Package.hs
+++ b/Handler/Package.hs
@@ -16,7 +16,7 @@ import qualified Data.Text.Lazy as LT
 import           Distribution.Package.ModuleForest
 import           Graphics.Badge.Barrier
 import           Control.Lens
-import           Import hiding (empty)
+import           Import
 import qualified Text.Blaze.Html.Renderer.Text as LT
 import           Text.Email.Validate
 import           Stackage.Database
@@ -161,13 +161,13 @@ data Identifier
 --
 parseIdentitiesLiberally :: Text -> [Identifier]
 parseIdentitiesLiberally =
-  filter (not . empty) .
+  filter (not . emptyPlainText) .
   map strip .
   concatPlains .
   map parseChunk .
   T.split (== ',')
-  where empty (PlainText e) = T.null e
-        empty _ = False
+  where emptyPlainText (PlainText e) = T.null e
+        emptyPlainText _ = False
         strip (PlainText t) = PlainText (T.strip t)
         strip x = x
         concatPlains = go

--- a/Stackage/Database.hs
+++ b/Stackage/Database.hs
@@ -470,7 +470,7 @@ snapshotTitle :: Snapshot -> Text
 snapshotTitle s = prettyName (snapshotName s) (snapshotGhc s)
 
 prettyName :: SnapName -> Text -> Text
-prettyName name ghc = concat [prettyNameShort name, " (GHC ", ghc, ")"]
+prettyName name ghc = concat [prettyNameShort name, " (ghc-", ghc, ")"]
 
 prettyNameShort :: SnapName -> Text
 prettyNameShort name =

--- a/Stackage/Database.hs
+++ b/Stackage/Database.hs
@@ -470,7 +470,7 @@ snapshotTitle :: Snapshot -> Text
 snapshotTitle s = prettyName (snapshotName s) (snapshotGhc s)
 
 prettyName :: SnapName -> Text -> Text
-prettyName name ghc = concat [prettyNameShort name, " - GHC ", ghc]
+prettyName name ghc = concat [prettyNameShort name, " (GHC ", ghc, ")"]
 
 prettyNameShort :: SnapName -> Text
 prettyNameShort name =

--- a/templates/package.hamlet
+++ b/templates/package.hamlet
@@ -15,10 +15,7 @@ $newline never
                       <a href="@{PackageR $ PackageName pn}">
                         #{pn}
             <h1>
-               #{pn} #
-               <span .latest-version>
-                 <a href="https://hackage.haskell.org/package/#{pn}">
-                   #{displayedVersion}
+               #{pn}
             <p .synopsis>
                 #{synopsis}
                \ #
@@ -30,7 +27,15 @@ $newline never
                  <div>
                    <a href=@{SnapshotR (liSnapName li) StackageHomeR}>
                       #{prettyName (liSnapName li) (liGhc li)}
-                   \: #{liVersion li}
+                   \: #
+                   <span .version>
+                      #{liVersion li}
+            <div>
+              <a href="https://hackage.haskell.org/package/#{pn}">
+                 Hackage
+              \: #
+              <span .version>
+                 #{displayedVersion} #
 
             $if null latests
                 <p .add-to-nightly>

--- a/templates/package.hamlet
+++ b/templates/package.hamlet
@@ -42,11 +42,11 @@ $newline never
         <div .span12>
             <div .authorship>
                 <span .license>
-                    #{packageLicenseName package} licensed
+                    #{packageLicenseName package} licensed #
                     $if null maintainers
                         and maintained #
                 $if not (null authors)
-                   \ by #
+                   by #
                    $forall (i,identity) <- authors
                       <strong .author>
                           $case identity

--- a/templates/package.hamlet
+++ b/templates/package.hamlet
@@ -26,11 +26,11 @@ $newline never
                    <a href="#{url}">
                        #{url}
 
-            $forall (idx, li) <- enumerate latests
-                 $if idx /= 0
-                    , #
-                 <a href=@{SnapshotR (liSnapName li) StackageHomeR}>
-                    #{prettyName (liSnapName li) (liGhc li)} (#{liVersion li})
+            $forall li <- latests
+                 <div>
+                   <a href=@{SnapshotR (liSnapName li) StackageHomeR}>
+                      #{prettyName (liSnapName li) (liGhc li)}
+                   \: #{liVersion li}
 
             $if null latests
                 <p .add-to-nightly>

--- a/templates/package.hamlet
+++ b/templates/package.hamlet
@@ -17,7 +17,8 @@ $newline never
             <h1>
                #{pn} #
                <span .latest-version>
-                 #{displayedVersion} #
+                 <a href="https://hackage.haskell.org/package/#{pn}">
+                   #{displayedVersion}
             <p .synopsis>
                 #{synopsis}
                \ #
@@ -41,12 +42,11 @@ $newline never
         <div .span12>
             <div .authorship>
                 <span .license>
-                    <a href="">
-                        #{packageLicenseName package} licensed #
+                    #{packageLicenseName package} licensed
                     $if null maintainers
                         and maintained #
                 $if not (null authors)
-                   by #
+                   \ by #
                    $forall (i,identity) <- authors
                       <strong .author>
                           $case identity
@@ -126,7 +126,7 @@ $if not (LT.null (LT.renderHtml (packageChangelog package)))
                             #{name}
             $if not $ null revdeps
               <div .reverse-dependencies .expanding #reverse-dependencies>
-                Used by
+                Used by #{length revdeps} packages:
                 <div .dep-list>
                     $forall (i,(name, range)) <- revdeps
                         $if i /= 0

--- a/templates/package.hamlet
+++ b/templates/package.hamlet
@@ -122,7 +122,7 @@ $if not (LT.null (LT.renderHtml (packageChangelog package)))
     <div .row>
         <div .span12>
             <div .dependencies #dependencies>
-                Depends on
+                Depends on:
                 <div .dep-list>
                     $forall (i,(name, range)) <- deps
                         $if i /= 0
@@ -131,7 +131,7 @@ $if not (LT.null (LT.renderHtml (packageChangelog package)))
                             #{name}
             $if not $ null revdeps
               <div .reverse-dependencies .expanding #reverse-dependencies>
-                Used by #{length revdeps} packages:
+                Used by #{renderNoPackages $ length revdeps}:
                 <div .dep-list>
                     $forall (i,(name, range)) <- revdeps
                         $if i /= 0

--- a/templates/package.lucius
+++ b/templates/package.lucius
@@ -11,9 +11,8 @@ h3 {
   width: auto;
   margin-left: auto;
 }
-.latest-version {
-  color: #777;
-  font-size: 24.5px;
+.version {
+  font-weight: bold;
 }
 #disqus_thread {
   margin-top: 2em;


### PR DESCRIPTION
- link to Hackage
- improve licensed by author markup
- print number of revdeps
- prettyName with ghc in parens
- list lts and nightly package versions on separate lines
