### PR TITLE
Script support for multi-AZ Kubernetes clusters and deployment from CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "etc/common/devops-helpers"]
+	path = etc/common/devops-helpers
+	url = https://github.com/fpco/devops-helpers.git

--- a/etc/build-deploy.sh
+++ b/etc/build-deploy.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -xe
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+ENV="$1"; shift
+stack --install-ghc test "$@"
+etc/docker/build.sh --no-build "$@"
+etc/docker/push.sh "$ENV"
+etc/kubernetes/deploy_rc.sh "$ENV"

--- a/etc/docker/build.sh
+++ b/etc/docker/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -xe
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+stack image container "$@"

--- a/etc/docker/push.sh
+++ b/etc/docker/push.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+exec "$(dirname "${BASH_SOURCE[0]}")/../common/devops-helpers/docker/push_helper.sh" \
+    --repo fpco/stackage-server "$@"

--- a/etc/kubernetes/deploy_rc.sh
+++ b/etc/kubernetes/deploy_rc.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+exec "$(dirname ${BASH_SOURCE[0]})/../common/devops-helpers/kubernetes/deploy_rc_helper.sh" \
+     --app "stackage-server" \
+     --repo fpco/stackage-server \
+     --specdir "$(dirname "${BASH_SOURCE[0]}")" \
+     --clusters ~/.kube/clusters/fpco-prod-us-east-1?/kubeconfig \
+     "$@"

--- a/etc/kubernetes/stackage-server-prod-rc.yaml
+++ b/etc/kubernetes/stackage-server-prod-rc.yaml
@@ -1,26 +1,6 @@
 # Kubernetes
 ---
 apiVersion: v1
-kind: Service
-metadata:
-  name: stackage-server-prod
-  labels:
-    app: stackage-server-prod
-spec:
-  ports:
-  - name: http
-    port: 80
-    nodePort: 31419
-    targetPort: http
-  - name: https
-    port: 443
-    nodePort: 30733
-    targetPort: http
-  type: NodePort
-  selector:
-    app: stackage-server-prod
----
-apiVersion: v1
 kind: ReplicationController
 metadata:
   name: stackage-server-prod-v0
@@ -34,7 +14,8 @@ spec:
     spec:
       containers:
       - name: stackage-server
-        image: snoyberg/stackage-server:latest
+        image: fpco/stackage-server:prod
+        imagePullPolicy: Always
         ports:
         - name: http
           containerPort: 3000

--- a/etc/kubernetes/stackage-server-prod-svc.yaml
+++ b/etc/kubernetes/stackage-server-prod-svc.yaml
@@ -1,0 +1,19 @@
+# Kubernetes
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stackage-server-prod
+  labels:
+    app: stackage-server-prod
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  - name: https
+    port: 443
+    targetPort: http
+  type: ClusterIP
+  selector:
+    app: stackage-server-prod

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 resolver: lts-5.1
 image:
     container:
-        name: snoyberg/stackage-server
+        name: fpco/stackage-server
         base: fpco/stack-run
         add:
             config: /app/config


### PR DESCRIPTION
I haven't set up the CI system yet (don't want to use Travis because building Docker images means no caching for public projects, and there doesn't seem to be a way to get a public project to use our Pro account which would support caching for this case), but the new scripts are still useful.  Basically:

* `etc/build-deploy.sh prod`: build the code, push a Docker image, and rolling-update the production clusters

That uses these scripts, which you can also run on their own:

* `etc/docker/build.sh`: build a Docker image (gives it the `latest` tag)
* `etc/docker/push.sh prod [--tag TAG]`: push the local `latest` image to the Docker registry with `prod` and `prod_COMMITID` tags
* `etc/kubernetes/deploy_rc.sh prod`: rolling-update the production clusters to the image with tag `prod_COMMITID`
