### PR TITLE
package.hamlet: use a table and prettyNameShort to render version list

### DIFF
--- a/templates/package.hamlet
+++ b/templates/package.hamlet
@@ -23,19 +23,24 @@ $newline never
                    <a href="#{url}">
                        #{url}
 
-            $forall li <- latests
-                 <div>
-                   <a href=@{SnapshotR (liSnapName li) StackageHomeR}>
-                      #{prettyName (liSnapName li) (liGhc li)}
-                   \: #
-                   <span .version>
-                      #{liVersion li}
-            <div>
-              <a href="https://hackage.haskell.org/package/#{pn}">
-                 Hackage
-              \: #
-              <span .version>
-                 #{displayedVersion} #
+            <table>
+              $forall li <- latests
+                 <tr>
+                   <td align="right">
+                     <a href=@{SnapshotR (liSnapName li) StackageHomeR}>
+                        #{prettyNameShort (liSnapName li)}
+                     \: #
+                   <td>
+                     <span .version>
+                       #{liVersion li}
+              <tr>
+                <td align="right">
+                  <a href="https://hackage.haskell.org/package/#{pn}">
+                     Hackage
+                  \: #
+                <td>
+                  <span .version>
+                    #{displayedVersion} #
 
             $if null latests
                 <p .add-to-nightly>


### PR DESCRIPTION
This should improve the readability of the package's version list further:

![screenshot](https://petersen.fedorapeople.org/stackage-server-package-table.png)

compared to current master: https://github.com/fpco/stackage-server/pull/156#issuecomment-186184710.