### PR TITLE
Link to changelogs in snapshot diff

### DIFF
--- a/Import.hs
+++ b/Import.hs
@@ -20,6 +20,11 @@ parseLtsPair t1 = do
     (y, "") <- either (const Nothing) Just $ decimal t3
     Just (x, y)
 
+packageUrl :: SnapName -> PackageName -> Version -> Route App
+packageUrl sname pkgname pkgver = SnapshotR sname sdistR
+  where
+    sdistR = StackageSdistR (PNVNameVersion pkgname pkgver)
+
 haddockUrl :: SnapName
            -> Text -- ^ package-version
            -> Text -- ^ module name

--- a/templates/package.hamlet
+++ b/templates/package.hamlet
@@ -111,7 +111,7 @@ $if not (LT.null (LT.renderHtml (packageDescription package)))
                         <i class="fa fa-angle-down">
 
 $if not (LT.null (LT.renderHtml (packageChangelog package)))
-    <div .container .content>
+    <div .container .content id=changes>
        <div .row>
            <div .span12>
                <h2 .changes-title>Changes

--- a/templates/stackage-diff.hamlet
+++ b/templates/stackage-diff.hamlet
@@ -38,18 +38,18 @@
             $case verChange
               $of This oldVersion
                 <td>
-                  <a href=@{packageUrl name1 pkgname oldVersion}>
+                  <a href=@{packageUrl name1 pkgname oldVersion}#changes}>
                     #{pkgname}-#{oldVersion}
                 <td>
               $of That newVersion
                 <td>
                 <td>
-                  <a href=@{packageUrl name2 pkgname newVersion}>
+                  <a href=@{packageUrl name2 pkgname newVersion}#changes>
                     #{pkgname}-#{newVersion}
               $of These oldVersion newVersion
                 <td>
-                  <a href=@{packageUrl name1 pkgname oldVersion}>
+                  <a href=@{packageUrl name1 pkgname oldVersion}#changes>
                     #{pkgname}-#{oldVersion}
                 <td>
-                  <a href=@{packageUrl name2 pkgname newVersion}>
+                  <a href=@{packageUrl name2 pkgname newVersion}#changes>
                     #{pkgname}-#{newVersion}

--- a/templates/stackage-diff.hamlet
+++ b/templates/stackage-diff.hamlet
@@ -33,15 +33,23 @@
                 $else
                   <option value=@{StackageDiffR name1 name2'}>#{toPathPiece name2'}
       <tbody>
-        $forall (PackageName name, VersionChange verChange) <- toDiffList snapDiff
+        $forall (pkgname, VersionChange verChange) <- toDiffList snapDiff
           <tr>
             $case verChange
-              $of This (Version oldVersion)
-                <td>#{name}-#{oldVersion}
+              $of This oldVersion
                 <td>
-              $of That (Version newVersion)
+                  <a href=@{packageUrl name1 pkgname oldVersion}>
+                    #{pkgname}-#{oldVersion}
                 <td>
-                <td>#{name}-#{newVersion}
-              $of These (Version oldVersion) (Version newVersion)
-                <td>#{name}-#{oldVersion}
-                <td>#{name}-#{newVersion}
+              $of That newVersion
+                <td>
+                <td>
+                  <a href=@{packageUrl name2 pkgname newVersion}>
+                    #{pkgname}-#{newVersion}
+              $of These oldVersion newVersion
+                <td>
+                  <a href=@{packageUrl name1 pkgname oldVersion}>
+                    #{pkgname}-#{oldVersion}
+                <td>
+                  <a href=@{packageUrl name2 pkgname newVersion}>
+                    #{pkgname}-#{newVersion}

--- a/templates/stackage-home.hamlet
+++ b/templates/stackage-home.hamlet
@@ -53,8 +53,7 @@ $newline never
                 $forall pli <- packages
                     <tr>
                         <td>
-                            <a href=@{SnapshotR name $ StackageSdistR $ PNVNameVersion (PackageName $ toPathPiece $ pliName pli) $ Version (pliVersion pli)}>
-                                #{pliName pli}
-                                -#{pliVersion pli}
+                            <a href=@{packageUrl name (PackageName $ pliName pli) (Version $ pliVersion pli)}>
+                                #{pliName pli}-#{pliVersion pli}
                         <td>
                             #{strip $ pliSynopsis pli}


### PR DESCRIPTION
Display links to changelogs of the packages on either side to aid in reviewing snapshot diffs. Since this uses a hash fragment to point to the id="changes" container, if there is no changelog the user will simply navigate to the package page.