### PR TITLE
Haddock style: move selflink to the right

### DIFF
--- a/static/haddock/style.css
+++ b/static/haddock/style.css
@@ -288,6 +288,13 @@ code .diff              { color:#555 }
 .src .def, .src .def:hover, .src a { color:#4F4371; text-decoration: none;}
 .src a[href]:hover { text-decoration: underline; }
 
+.top > .src > .selflink {
+  padding-right: 0.5em;
+  float: right;
+  font-family: "Open Sans", sans-serif;
+  color: #428bca;
+}
+
 .top > .src > .link {
   float: right;
   font-family: "Open Sans", sans-serif;
@@ -384,5 +391,3 @@ h4.collapser { font-size: 15px; font-weight: bold }
 }
 
 .doc.empty { display: none; }
-
-a.selflink { float right; padding-right: 0.5em }


### PR DESCRIPTION
I believe the last commit to this file was aimed to that end, but there is a `:` missing, syntactically. I also thought it looks better if the font style matches that of `Source`.

Before:
![selection_001](https://cloud.githubusercontent.com/assets/10927795/16879513/2b57ce7a-4ab1-11e6-9f9d-352c688b544d.png)

After:
![selection_002](https://cloud.githubusercontent.com/assets/10927795/16879622/b249c8f2-4ab1-11e6-9fca-85af3ad404f9.png)
