### PR TITLE
Added code font styling fallback

### DIFF
--- a/static/haddock/style.css
+++ b/static/haddock/style.css
@@ -616,7 +616,7 @@ a[href] {
 }
 .caption { color: #6e618d!important }
 pre{ background: #f8f8f8; padding: 1em; }
-pre, pre * {  font-family: "ubuntu mono", "Monaco"  !important; font-size: 13px !important; }
+pre, pre * {  font-family: "ubuntu mono", "Monaco", "Consolas", monospace !important; font-size: 13px !important; }
 #table-of-contents {
   background: #f8f8f8;
   border: 1px solid #eee;


### PR DESCRIPTION
For computers that don't have either Ubuntu Mono or Monaco fonts installed, there should be a fallback font so we don't display code in a non-Monospaced font.

I've added Consolas for the Windows users (such as myself :smile:), and a final fallback to the default browser monospace font if even that fails.

This would fix #199.