### PR TITLE
Adds a link to the adding-a-package section.

### DIFF
--- a/templates/home.hamlet
+++ b/templates/home.hamlet
@@ -53,6 +53,12 @@
                 $forall (major, minor, ghc) <- latestLtsByGhc
                   <li>
                     <a href=@{SnapshotR (SNLts major minor) StackageHomeR}>LTS #{major}.#{minor} for GHC #{ghc}
+            <h3>
+                Package Maintainers
+            <p>
+                <a href="https://github.com/fpco/stackage/blob/master/MAINTAINERS.md#adding-a-package">
+                  Add your maintained packages to stackage
+                    
       <div .span6>
         <h3>Snapshots
         $forall stackages <- groups


### PR DESCRIPTION
This adds a link to the MAINTAINERS.md file, so that new maintains can find this information right from the stackage.org website.