### PR TITLE
update CI spec to use Gitlab review apps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,9 @@ stages:
 
 variables:
     STACK_ROOT: "${CI_PROJECT_DIR}/.stack-root"
-    DOCKER_IMAGE: "${CI_REGISTRY_IMAGE}:${CI_BUILD_REF_SLUG}_${CI_PIPELINE_ID}"
+    DEPLOYMENT_IMAGE: "${CI_REGISTRY_IMAGE}:${CI_BUILD_REF_SLUG}_${CI_PIPELINE_ID}"
+    DEPLOYMENT_NAME: "stackage-server-${CI_BUILD_REF_SLUG}"
+    DEPLOYMENT_APP: "${CI_ENVIRONMENT_SLUG}"
 
 # This creates anchors for bits of script that are reused between builds
 .anchors:
@@ -23,48 +25,67 @@ variables:
     kubectl config set-cluster cluster --server="$KUBE_URL" --certificate-authority="$HOME/ca.pem" &&
     kubectl config set-credentials cluster --token="$KUBE_TOKEN" && kubectl config set-context cluster --cluster=cluster --user=cluster --namespace="$KUBE_NAMESPACE" &&
     kubectl config use-context cluster
+  - &KUBEAPPLY
+    kubectl apply -f <(envsubst <etc/kube/service_template.yaml) &&
+    kubectl apply -f <(envsubst <etc/kube/deployment_template.yaml) &&
+    kubectl rollout status -f <(envsubst <etc/kube/deployment_template.yaml)
 
 build:
   stage: build
-  only:
-    - master
-    - prod
   script:
     # Clear *_TOKEN variables during code build so that compile-time code can't access them
     - CI_BUILD_TOKEN="" KUBE_TOKEN="" PROD_KUBE_TOKEN="" PROD_DOCKER_PASSWORD="" etc/scripts/stage_docker.sh --install-ghc --test
-    - docker build -t "${DOCKER_IMAGE}" etc/docker
+    - docker build -t "${DEPLOYMENT_IMAGE}" etc/docker
     - docker login -u gitlab-ci-token -p "${CI_BUILD_TOKEN}" "${CI_REGISTRY}"
-    - docker push "${DOCKER_IMAGE}"
+    - docker push "${DEPLOYMENT_IMAGE}"
     - |
       if [[ "$CI_BUILD_REF_NAME" == "master" ]]; then
-        docker tag "${DOCKER_IMAGE}" "${CI_REGISTRY_IMAGE}:latest"
+        docker tag "${DEPLOYMENT_IMAGE}" "${CI_REGISTRY_IMAGE}:latest"
         docker push "${CI_REGISTRY_IMAGE}:latest"
       fi
 
-deploy_master:
+deploy_review:
   stage: deploy
   only:
+    - branches
+  except:
     - master
   environment:
-    name: stackage-server-ci
-    url: https://ci.stackage.org/
+    name: stackage-server-review/$CI_BUILD_REF_NAME
+    url: https://stackage-server-$CI_BUILD_REF_SLUG.review.fpco-untrusted.fpcomplete.com/
+    on_stop: stop_review
   variables:
-    DEPLOYMENT_NAME: "stackage-server-ci"
+    APPROOT: https://stackage-server-$CI_BUILD_REF_SLUG.review.fpco-untrusted.fpcomplete.com/
   script:
     - *KUBELOGIN
-    - kubectl set image "deployment/$DEPLOYMENT_NAME" stackage-server="$DOCKER_IMAGE"
-    - kubectl rollout status "deployment/$DEPLOYMENT_NAME"
+    - echo $KUBE_URL
+    - echo $APPROOT
+    - *KUBEAPPLY
+
+stop_review:
+  stage: deploy
+  only:
+    - branches
+  except:
+    - master
+  when: manual
+  environment:
+    name: stackage-server-review/$CI_BUILD_REF_NAME
+    action: stop
+  script:
+    - *KUBELOGIN
+    - kubectl delete service,deployment -l app=${CI_ENVIRONMENT_SLUG}
 
 deploy_prod:
   stage: deploy
   only:
-    - prod
+    - master
   environment:
     name: stackage-server-prod
     url: https://www.stackage.org/
   variables:
     DEPLOYMENT_NAME: "stackage-server-prod"
-    PROD_DOCKER_IMAGE: "fpco/stackage-server-prod:${CI_BUILD_REF_SLUG}_${CI_PIPELINE_ID}"
+    PROD_DEPLOYMENT_IMAGE: "fpco/stackage-server-prod:${CI_BUILD_REF_SLUG}_${CI_PIPELINE_ID}"
   script:
     - export
       KUBE_CA_PEM="$PROD_KUBE_CA_PEM"
@@ -73,9 +94,9 @@ deploy_prod:
       KUBE_NAMESPACE="$PROD_KUBE_NAMESPACE"
     - *KUBELOGIN
     - docker login -u "$PROD_DOCKER_USERNAME" -p "${PROD_DOCKER_PASSWORD}"
-    - docker tag "$DOCKER_IMAGE" "$PROD_DOCKER_IMAGE"
-    - docker push "$PROD_DOCKER_IMAGE"
-    - docker tag "$DOCKER_IMAGE" "fpco/stackage-server-prod:latest"
+    - docker tag "$DEPLOYMENT_IMAGE" "$PROD_DEPLOYMENT_IMAGE"
+    - docker push "$PROD_DEPLOYMENT_IMAGE"
+    - docker tag "$DEPLOYMENT_IMAGE" "fpco/stackage-server-prod:latest"
     - docker push "fpco/stackage-server-prod:latest"
     - kubectl set image "deployment/$DEPLOYMENT_NAME" stackage-server="$PROD_DOCKER_IMAGE"
     - kubectl rollout status "deployment/$DEPLOYMENT_NAME"

--- a/etc/kube/deployment_template.yaml
+++ b/etc/kube/deployment_template.yaml
@@ -1,0 +1,53 @@
+# Kubernetes
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "${DEPLOYMENT_NAME}"
+spec:
+  replicas: 2
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app: "${DEPLOYMENT_APP}"
+    spec:
+      containers:
+        - name: stackage-server
+          image: "${DEPLOYMENT_IMAGE}"
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 3000
+          command: ["stackage-server"]
+          workingDir: /app
+          env:
+            - name: APPROOT
+              value: "${APPROOT}"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+              httpHeaders:
+                # Works around stackage-server's `forceSSL` redirect
+                - name: HTTPS
+                  value: "on"
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+              httpHeaders:
+                # Works around stackage-server's `forceSSL` redirect
+                - name: HTTPS
+                  value: "on"
+            initialDelaySeconds: 60
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+      imagePullSecrets:
+        - name: registry-key

--- a/etc/kube/service_template.yaml
+++ b/etc/kube/service_template.yaml
@@ -1,0 +1,19 @@
+# Kubernetes
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "${DEPLOYMENT_NAME}"
+  labels:
+    app: "${DEPLOYMENT_APP}"
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  - name: https
+    port: 443
+    targetPort: http
+  selector:
+    app: "${DEPLOYMENT_APP}"
+  type: ClusterIP


### PR DESCRIPTION
Summary of changes:

* rename DOCKER_IMAGE to DEPLOYMENT_IMAGE
* docker image builds now run for any branch/tag
* include jobs for deploying and stopping the review app on kube
* review apps are deployed to the `fpco-untrusted` cluster
* review apps are available based the following URL scheme:
  https://stackage-server-$CI_BUILD_REF_SLUG.review.fpco-untrusted.fpcomplete.com/
* master deploys to prod, and the previous staging env has been dropped
* import the kube specs we've used in CI/prod, update to use envvars
  for APPROOT, DEPLOYMENT_APP, DEPLOYMENT_NAME, and DEPLOYMENT_IMAGE

Heads up: when merging this PR to master, gitlab will deploy that branch to prod.