### PR TITLE
Provide a link to offline snapshot doc archive

### DIFF
--- a/templates/stackage-home.hamlet
+++ b/templates/stackage-home.hamlet
@@ -28,6 +28,7 @@ $newline never
 
     <p>
         <a href=@{SnapshotR name DocsR}>View documentation by modules
+        <a href="https://s3.amazonaws.com/haddock.stackage.org/#{toPathPiece name}/bundle.tar.xz">Download documentation archive
 
 <div .container .content>
     <div .packages>


### PR DESCRIPTION
Following up on discussion here: https://github.com/fpco/stackage/issues/2788#issuecomment-324012397

This builds for me, but I am sadly unable to test it locally. My attempts to do so hang on `Downloading database to stackage-database/database-download-1`.