### PR TITLE
Prometheus upgrade

### DIFF
--- a/Import.hs
+++ b/Import.hs
@@ -52,16 +52,16 @@ track name inner = do
     return result
   where
     {-# NOINLINE duration #-}
-    duration :: P.Metric (P.Vector P.Label1 P.Summary)
+    duration :: P.Metric (P.Vector P.Label1 P.Histogram)
     duration =
         P.unsafeRegisterIO
             (P.vector
                  "fn"
-                 (P.summary
+                 (P.histogram
                       (P.Info
                            "stackage_server_fn"
                            "Stackage Server function call (duration in microseconds).")
-                      P.defaultQuantiles))
+                      P.defaultBuckets))
 
 dateDiff :: UTCTime -- ^ now
          -> Day -- ^ target

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.12
+resolver: lts-9.13
 packages:
 - .
 - location:
@@ -7,8 +7,8 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/commercialhaskell/all-cabal-metadata-tool
-    commit: 1a4d8cff4e796ea0049537a38e38ec0a739caf64
+    commit: ea541be73238a5ce14ad26f4e2a94e63981242a4
   extra-dep: true
 extra-deps:
-- aws-0.16
 - barrier-0.1.1
+- spoon-0.3.1


### PR DESCRIPTION
This provides the ability to aggregate results in Prometheus, allowing
metrics such as “average time per handler executed”. Summaries do not
provide this facility, and since their use-case for other views on
Prometheus is similar on `stackage-server`’s use-cases, it has been
completely changed to Histograms.

Since this demands a newer version of the Prometheus library, I have updated the snapshot and brought in bug-fixes from `all-cabal-metadata-tool` alongside in a separate commit.