### PR TITLE
Highlight package version differences

### DIFF
--- a/src/Stackage/Snapshot/Diff.hs
+++ b/src/Stackage/Snapshot/Diff.hs
@@ -38,12 +38,12 @@ instance ToJSON (WithSnapshotNames SnapshotDiff) where
 toDiffList :: SnapshotDiff -> [(PackageName, VersionChange)]
 toDiffList = sortOn (toCaseFold . unPackageName . fst) . HashMap.toList . unSnapshotDiff
 
-versionPrefix :: VersionChange -> Maybe (Text,Text,Text)
+versionPrefix :: VersionChange -> Maybe (Text, Text, Text)
 versionPrefix vc = case unVersionChange vc of
         These (Version a) (Version b) -> T.commonPrefixes a b
         _ -> Nothing
 
-versionedDiffList :: [(PackageName, VersionChange)] -> [(PackageName, VersionChange, Maybe (Text,Text,Text))]
+versionedDiffList :: [(PackageName, VersionChange)] -> [(PackageName, VersionChange, Maybe (Text, Text, Text))]
 versionedDiffList = map withPrefixedVersion
   where
     withPrefixedVersion (packageName, versionChange) = (packageName, versionChange, versionPrefix versionChange)

--- a/templates/package-list.lucius
+++ b/templates/package-list.lucius
@@ -2,4 +2,13 @@
   .table th, .table td {
     padding-left: 0;
   }
+
+  .table span.version-removed {
+    background-color: red;
+    text-decoration: line-through;
+  }
+
+  .table span.version-added {
+    background-color: green;
+  }
 }

--- a/templates/stackage-diff.hamlet
+++ b/templates/stackage-diff.hamlet
@@ -33,7 +33,7 @@
                 $else
                   <option value=@{StackageDiffR name1 name2'}>#{toPathPiece name2'}
       <tbody>
-        $forall (pkgname, VersionChange verChange) <- toDiffList snapDiff
+        $forall (pkgname, VersionChange verChange, versionDiff) <- toVersionedDiffList snapDiff
           <tr>
             $case verChange
               $of This oldVersion
@@ -47,9 +47,19 @@
                   <a href=@{packageUrl name2 pkgname newVersion}#changes>
                     #{pkgname}-#{newVersion}
               $of These oldVersion newVersion
-                <td>
-                  <a href=@{packageUrl name1 pkgname oldVersion}#changes>
-                    #{pkgname}-#{oldVersion}
-                <td>
-                  <a href=@{packageUrl name2 pkgname newVersion}#changes>
-                    #{pkgname}-#{newVersion}
+                $maybe (common, old, new) <- versionDiff
+                  <td>
+                    <a href=@{packageUrl name1 pkgname oldVersion}#changes>
+                      #{pkgname}-#{common}#
+                      <span .version-removed>#{old}
+                  <td>
+                    <a href=@{packageUrl name2 pkgname newVersion}#changes>
+                      #{pkgname}-#{common}#
+                      <span .version-added>#{new}
+                $nothing
+                  <td>
+                    <a href=@{packageUrl name1 pkgname oldVersion}#changes>
+                      #{pkgname}-#{oldVersion}
+                  <td>
+                    <a href=@{packageUrl name2 pkgname newVersion}#changes>
+                      #{pkgname}-#{newVersion}


### PR DESCRIPTION
Sometimes it's quite hard to spot the difference between package versions, as they look like a bunch of numbers to the user. This introduces highlighting them if version numbers have anything in common (determined with `commonPrefixes`) with color and adjusted text style. 

NB: That's a really crude implementation, because I couldn't manage to run neither development (`yesod devel`), nor non-development versions on my Linux box. 