### PR TITLE
Enable synopsis back

### DIFF
--- a/static/haddock/style.css
+++ b/static/haddock/style.css
@@ -311,9 +311,10 @@ div#style-menu-holder {
   display: none;
 }
 
-#synopsis {
-  display: none;
-}
+/* Fixes: https://github.com/fpco/stackage-server/issues/222 */
+/* #synopsis { */
+/*   display: none; */
+/* } */
 
 .no-frame #synopsis {
   display: block;


### PR DESCRIPTION
This will hopefully fix: https://github.com/fpco/stackage-server/issues/222

Not tested locally, as there doesn't seem to be a easy way to run it locally as of now.