### PR TITLE
Support for local installation of stackage-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ Server for stable, curated Haskell package sets
 This repo is part of the [Stackage project](https://github.com/fpco/stackage),
 and the live server can be viewed at https://www.stackage.org.
 
-postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
-
-postgresql://postgres:password@localhost:5432/stackage
-
 ## Building locally
 
 Build locally by passing the `dev` flag to it:

--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ $ export PGSTRING=postgresql://postgres:password@localhost:5432/stackage
 $ stack exec stackage-server-cron
 ```
 
+Note that you need to modify the PGSTRING according to your actual database configuration. Also, you need to create an empty database before running the cron job.
+
 After this, try running in the stackage server:
 
 ``` shellsession
+$ export PGSTRING=postgresql://postgres:password@localhost:5432/stackage
 $ stack exec stackage-server
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,3 +7,30 @@ Server for stable, curated Haskell package sets
 
 This repo is part of the [Stackage project](https://github.com/fpco/stackage),
 and the live server can be viewed at https://www.stackage.org.
+
+postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
+
+postgresql://postgres:password@localhost:5432/stackage
+
+## Building locally
+
+Build locally by passing the `dev` flag to it:
+
+``` shellsession
+$ stack build . --flag stackage-server:dev
+```
+
+Now, initially you need to run the cron job and create and populate the database:
+
+``` shellsession
+$ export PGSTRING=postgresql://postgres:password@localhost:5432/stackage
+$ stack exec stackage-server-cron
+```
+
+After this, try running in the stackage server:
+
+``` shellsession
+$ stack exec stackage-server
+```
+
+

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ export PGSTRING=postgresql://postgres:password@localhost:5432/stackage
 $ stack exec stackage-server-cron
 ```
 
-Note that you need to modify the PGSTRING according to your actual database configuration. Also, you need to create an empty database before running the cron job.
+Note that you need to modify the PGSTRING according to your actual database configuration. Also, you need to create an empty database before running the cron job. Note that it takes quites some time for it to load your database.
 
 After this, try running in the stackage server:
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ Build locally by passing the `dev` flag to it:
 $ stack build . --flag stackage-server:dev
 ```
 
-Now, initially you need to run the cron job and create and populate the database:
+Now, initially you need to run the cron job to create and populate the database:
 
 ``` shellsession
 $ export PGSTRING=postgresql://postgres:password@localhost:5432/stackage
 $ stack exec stackage-server-cron
 ```
 
-Note that you need to modify the PGSTRING according to your actual database configuration. Also, you need to create an empty database before running the cron job. Note that it takes quites some time for it to load your database.
+Note that you need to modify the PGSTRING environment variable according to your actual database configuration. Also, you need to create an empty database before running the cron job. Note that it takes quites some time for it to load your database.
 
-After this, try running in the stackage server:
+After this, run the stackage server:
 
 ``` shellsession
 $ export PGSTRING=postgresql://postgres:password@localhost:5432/stackage

--- a/package.yaml
+++ b/package.yaml
@@ -147,6 +147,8 @@ executables:
     when:
     - condition: flag(library-only)
       buildable: false
+    - condition: flag(dev)
+      cpp-options: -DDEVELOPMENT
 
   stackage-server-cron:
     main: stackage-server-cron.hs
@@ -161,3 +163,5 @@ executables:
     when:
     - condition: flag(library-only)
       buildable: false
+    - condition: flag(dev)
+      cpp-options: -DDEVELOPMENT

--- a/src/Application.hs
+++ b/src/Application.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE CPP#-}
 module Application
     ( getApplicationDev
     , appMain
@@ -81,7 +82,9 @@ makeApplication foundation = do
     appPlain <- toWaiAppPlain foundation
 
     let middleware = id -- prometheus def
+#if !DEVELOPMENT
                    . forceSSL' (appSettings foundation)
+#endif
                    . logWare
                    . defaultMiddlewaresNoLogging
 

--- a/src/Stackage/Database/Cron.hs
+++ b/src/Stackage/Database/Cron.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP#-}
 module Stackage.Database.Cron
     ( stackageServerCron
     , newHoogleLocker
@@ -107,6 +108,7 @@ stackageServerCron = do
           }
     createStackageDatabase dbfp
 
+#if !DEVELOPMENT          
     db <- openStackageDatabase dbfp
 
     do
@@ -139,6 +141,7 @@ stackageServerCron = do
                     let dest = unpack key
                     createDirectoryIfMissing True $ takeDirectory dest
                     renamePath fp dest
+#endif
 
 createHoogleDB :: StackageDatabase -> Manager -> SnapName -> IO (Maybe FilePath)
 createHoogleDB db man name = handleAny (\e -> print e $> Nothing) $ do


### PR DESCRIPTION
Right now, running stackage server requires AWS credentials and so.

This PR will help others to run this locally without needing any external infrastructure. 