### PR TITLE
Haskell lang rename

### DIFF
--- a/src/Stackage/Database.hs
+++ b/src/Stackage/Database.hs
@@ -352,7 +352,7 @@ addPackage e =
     base = takeBaseName fp
 
     renderContent txt "markdown" = preEscapedToHtml $ commonmarkToHtml
-                                    [optSmart, optSafe]
+                                    [optSmart]
                                     [extTable, extAutolink]
                                     txt
     renderContent txt "haddock" = renderHaddock txt

--- a/src/Stackage/Database/Haddock.hs
+++ b/src/Stackage/Database/Haddock.hs
@@ -10,7 +10,7 @@ import ClassyPrelude.Conduit
 import Text.Blaze.Html (Html, toHtml)
 
 renderHaddock :: Text -> Html
-renderHaddock = hToHtml . Haddock.toRegular . _doc . Haddock.parseParas . unpack
+renderHaddock = hToHtml . Haddock.toRegular . _doc . Haddock.parseParas Nothing . unpack
 
 -- | Convert a Haddock doc to HTML.
 hToHtml :: DocH String String -> Html

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,1 @@
-resolver: nightly-2018-06-20
-extra-deps:
-- archive: https://github.com/bitemyapp/esqueleto/archive/b81e0d951e510ebffca03c5a58658ad884cc6fbd.tar.gz
-- archive: https://github.com/snoyberg/githash/archive/be83d64078e7940ce595c5c09efbd8d7d26beff0.tar.gz
-- archive: https://github.com/snoyberg/yesod-gitrev/archive/5364cf7ffa6b49b46173a99a7f1b48de4f660170.tar.gz
+resolver: lts-13.9

--- a/templates/home.hamlet
+++ b/templates/home.hamlet
@@ -54,17 +54,19 @@
 
             <p>
                 Have more questions? We have a #
-                <a href="https://github.com/fpco/stackage#frequently-asked-questions">FAQ section on Github
-                .
+                <a href="https://github.com/fpco/stackage#frequently-asked-questions">FAQ section on Github#
+                \.
             <h3>
                 Related initiatives
             <p>
-                Get started with using Stackage with our tool called Stack at our
-                <a href="https://haskell-lang.org/get-started">
-                    Getting Started
+                Stack is the recommended way to use Stackage.
+            <p>
+                <a href="https://haskell.fpcomplete.com/get-started">
+                    Get started with Stack
                 on
-                <a href="https://haskell-lang.org/">
-                  haskell-lang.org
+                <a href="https://haskell.fpcomplete.com/">#
+                    haskell.fpcomplete.com#
+                \.
 
             <h3>
                 Latest LTS per GHC version


### PR DESCRIPTION
Fixes #264. I slightly reworded the text by the link, as well.

Also includes minor changes that bump it up to lts-13.9

* `optSafe` is apparently now the default & therefore not exported
* `parseParas` now accepts a `Maybe Package`. I assume that passing in `Nothing` gets us to the behavior as before...

Works on my machine.