### PR TITLE
Fix priority of core packages:

### DIFF
--- a/app/stackage-server-cron.hs
+++ b/app/stackage-server-cron.hs
@@ -67,7 +67,7 @@ optsParser =
     switch
         (long "cache-cabal-files" <>
          help
-             ("Improve performance by cached parsed cabal files" ++
+             ("Improve performance by caching parsed cabal files" ++
               " at expense of higher memory consumption"))
   where
     repoAccount = "commercialhaskell"


### PR DESCRIPTION
* `global-hints.yaml` is now used as a fallback for packages that are not included in the snapshot
* Fix ordering of dependencies on the package page