### PR TITLE
Make sure links to haddocks are not generated for modules that have no haddock

### DIFF
--- a/src/Stackage/Database/Types.hs
+++ b/src/Stackage/Database/Types.hs
@@ -251,7 +251,7 @@ data SnapshotPackagePageInfo = SnapshotPackagePageInfo
     , sppiReverseDepsCount       :: !Int
     -- ^ Count of all packages in the snapshot that depends on this package
     , sppiLatestInfo             :: ![LatestInfo]
-    , sppiModuleNames            :: ![ModuleNameP]
+    , sppiModuleNames            :: !(Map ModuleNameP Bool)
     , sppiPantryCabal            :: !(Maybe PantryCabal)
     , sppiVersion                :: !(Maybe VersionRev)
     -- ^ Version on this page. Should be present only if different from latest


### PR DESCRIPTION
At the top of the module some devs can add a pragma `{-# OPTIONS_HADDOCK hide, not-home #-}`
which makes haddock not be generated for these modules, despite that they are still exposed and can be imported from the outside.

Currently on stackage these modules have links generated for them, which result in 404s since there are no docs for those modules. This PR fixes that, by simply not generating links (but still showing the names) for such modules. Hackage seems to have the same behavior.

Good example is current `QuickCheck`:
* On hackage: https://hackage.haskell.org/package/QuickCheck
* On stackage: https://www.stackage.org/package/QuickCheck (note links), so this is a 404 https://www.stackage.org/haddock/nightly-2019-07-11/QuickCheck-2.13.2/Test-QuickCheck-Exception.html
* How it should be: https://lehins.net/package/QuickCheck