### PR TITLE
Implemented automatic undeprecation of previously deprecated packages

### DIFF
--- a/src/Stackage/Database/Cron.hs
+++ b/src/Stackage/Database/Cron.hs
@@ -218,10 +218,10 @@ runStackageUpdate doNotUpload = do
     runStackageMigrations
     didUpdate <- forceUpdateHackageIndex (Just "stackage-server cron job")
     case didUpdate of
-        UpdateOccurred -> do
-            logInfo "Updated hackage index. Getting deprecated info now"
-            getHackageDeprecations >>= run . mapM_ addDeprecated
+        UpdateOccurred -> logInfo "Updated hackage index"
         NoUpdateOccurred -> logInfo "No new packages in hackage index"
+    logInfo "Getting deprecated info now"
+    getHackageDeprecations >>= setDeprecations
     corePackageGetters <- makeCorePackageGetters
     runResourceT $
         join $


### PR DESCRIPTION
Currently [`doldol`](https://www.stackage.org/nightly-2019-07-29/package/doldol-0.4.1.2) is listed as deprecated, despite that it is not listed as such on Hackage. This has likely happened because the maintainer of doldol has deprecated the package temporarily and later undeprecated it. This PR implements automatic undeprecation of Hackage packages.