### PR TITLE
Improve the snapshot diff view

### DIFF
--- a/templates/stackage-diff.hamlet
+++ b/templates/stackage-diff.hamlet
@@ -37,29 +37,31 @@
           <tr>
             $case verChange
               $of This oldVersion
+                <td> #{pkgname}
                 <td>
-                  <a href=@{packageUrl name1 pkgname oldVersion}#changes}>
-                    #{pkgname}-#{oldVersion}
-                <td>
+                  <a href=@{packageUrl name1 pkgname oldVersion}#changes>
+                    <span .version-removed>#{oldVersion}
               $of That newVersion
-                <td>
+                <td> #{pkgname}
                 <td>
                   <a href=@{packageUrl name2 pkgname newVersion}#changes>
-                    #{pkgname}-#{newVersion}
+                    <span .version-added>#{newVersion}
               $of These oldVersion newVersion
                 $maybe (common, old, new) <- versionDiff
+                  <td> #{pkgname}
                   <td>
                     <a href=@{packageUrl name1 pkgname oldVersion}#changes>
-                      #{pkgname}-#{common}#
+                      #{common}#
                       <span .version-removed>#{old}
-                  <td>
+                    &rarr;
                     <a href=@{packageUrl name2 pkgname newVersion}#changes>
-                      #{pkgname}-#{common}#
+                      #{common}#
                       <span .version-added>#{new}
                 $nothing
+                  <td> #{pkgname}
                   <td>
                     <a href=@{packageUrl name1 pkgname oldVersion}#changes>
-                      #{pkgname}-#{oldVersion}
-                  <td>
+                      <span .version-removed>#{oldVersion}
+                    &rarr;
                     <a href=@{packageUrl name2 pkgname newVersion}#changes>
-                      #{pkgname}-#{newVersion}
+                      <span .version-added>#{newVersion}


### PR DESCRIPTION
Replaced "package-name-1.2.3.4 package-2.3.4.5" representation with
"package-name 1.2.3.4 → 2.3.4.5", since package name is always the same.

Also removed rogue `}` from the URL of the deleted package.

before: 
![Screenshot from 2019-12-10 17-33-17](https://user-images.githubusercontent.com/89889/70538580-66e9aa80-1b73-11ea-8e1b-1e35a022b544.png)

after: 
![Screenshot from 2019-12-10 17-33-57](https://user-images.githubusercontent.com/89889/70538598-6ea94f00-1b73-11ea-8750-d557af3ed0db.png)

Not sure, though, what to do with these two wide mostly empty columns and how to improve discoverability of the fact the version number is a link to the doc exactly. 

  
