### PR TITLE
External cabal files

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,7 @@ dependencies:
 - persistent-template
 - resourcet
 - rio
+- semialign
 - shakespeare
 - tar-conduit
 - template-haskell

--- a/src/Data/WebsiteContent.hs
+++ b/src/Data/WebsiteContent.hs
@@ -11,7 +11,6 @@ module Data.WebsiteContent
 
 import ClassyPrelude.Yesod
 import CMarkGFM
-import Data.Aeson (withObject)
 import Data.GhcLinks
 import Data.Yaml
 import System.FilePath (takeFileName)

--- a/src/Handler/Blog.hs
+++ b/src/Handler/Blog.hs
@@ -86,4 +86,5 @@ getBlogFeedR = do
             , feedEntryTitle = postTitle post
             , feedEntryContent = postBody post
             , feedEntryEnclosure = Nothing
+            , feedEntryCategories = []
             }

--- a/src/Handler/Download.hs
+++ b/src/Handler/Download.hs
@@ -12,7 +12,6 @@ import Import
 import Data.GhcLinks
 import Yesod.GitRepo (grContent)
 import Stackage.Database
-import Stackage.Database.Types (ghcVersion)
 
 getDownloadR :: Handler Html
 getDownloadR = track "Hoogle.Download.getDownloadR" $

--- a/src/Handler/Feed.hs
+++ b/src/Handler/Feed.hs
@@ -12,7 +12,6 @@ import RIO.Time (getCurrentTime)
 import Stackage.Database
 import Stackage.Snapshot.Diff
 import Text.Blaze (text)
-import Yesod.Core.Handler (lookupGetParam)
 
 getFeedR :: Handler TypedContent
 getFeedR = track "Handler.Feed.getBranchFeedR" $ getBranchFeed Nothing
@@ -38,6 +37,7 @@ mkFeed mBranch snaps = do
             , feedEntryTitle = snapshotTitle snap
             , feedEntryContent = content
             , feedEntryEnclosure = Nothing
+            , feedEntryCategories = []
             }
     updated <-
         case entries of

--- a/src/Handler/Haddock.hs
+++ b/src/Handler/Haddock.hs
@@ -7,7 +7,6 @@ module Handler.Haddock
 import Import
 import qualified Data.Text as T (takeEnd)
 import Stackage.Database
-import Stackage.Database.Types (haddockBucketName)
 
 makeURL :: SnapName -> [Text] -> Text
 makeURL snapName rest = concat

--- a/src/Handler/Hoogle.hs
+++ b/src/Handler/Hoogle.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Handler.Hoogle where
 
-import Control.DeepSeq (NFData(..))
 import qualified Data.Text as T
 import Data.Text.Read (decimal)
 import qualified Hoogle

--- a/src/Handler/MirrorStatus.hs
+++ b/src/Handler/MirrorStatus.hs
@@ -8,7 +8,7 @@ module Handler.MirrorStatus
 import Import
 import Control.AutoUpdate
 import Network.HTTP.Simple
-import RIO.Time (parseTimeM, diffUTCTime, addUTCTime, getCurrentTime)
+import RIO.Time (diffUTCTime, addUTCTime, getCurrentTime)
 import Text.XML.Stream.Parse
 import Data.XML.Types (Event (EventContent), Content (ContentText))
 import qualified Prelude

--- a/src/Handler/Package.hs
+++ b/src/Handler/Package.hs
@@ -73,9 +73,7 @@ checkSpam pname inner = do
         $(widgetFile "spam-package")
       else inner
 
-packagePage :: Maybe SnapshotPackageInfo
-            -> PackageNameP
-            -> Handler Html
+packagePage :: Maybe SnapshotPackageInfo -> PackageNameP -> Handler Html
 packagePage mspi pname =
     track "Handler.Package.packagePage" $
     checkSpam pname $
@@ -84,8 +82,6 @@ packagePage mspi pname =
             hci <- run (getHackageLatestVersion pname) >>= maybe notFound pure
             handlePackage $ Left hci
           Just spi -> handlePackage $ Right spi
-
-
 
 
 handlePackage :: Either HackageCabalInfo SnapshotPackageInfo -> Handler Html

--- a/src/Handler/Package.hs
+++ b/src/Handler/Package.hs
@@ -27,8 +27,6 @@ import Graphics.Badge.Barrier
 import Import
 import Stackage.Database
 import Stackage.Database.PackageInfo (PackageInfo(..), Identifier(..), renderEmail)
-import Stackage.Database.Types (HackageCabalInfo(..), LatestInfo(..),
-                                ModuleListingInfo(..))
 import qualified Text.Blaze.Html.Renderer.Text as LT
 import Yesod.GitRepo
 

--- a/src/Handler/PackageDeps.hs
+++ b/src/Handler/PackageDeps.hs
@@ -9,9 +9,7 @@ module Handler.PackageDeps
 
 import Handler.StackageSdist (pnvToSnapshotPackageInfo)
 import Import
-import Types (PackageVersionRev(..))
 import Stackage.Database
-import Stackage.Database.Types (SnapshotPackageInfo(..))
 
 getPackageDepsR :: PackageNameP -> Handler Html
 getPackageDepsR pname = do

--- a/src/Handler/StackageHome.hs
+++ b/src/Handler/StackageHome.hs
@@ -17,7 +17,6 @@ import Data.These
 import RIO.Time (FormatTime)
 import Import
 import Stackage.Database
-import Stackage.Database.Types (PackageListingInfo(..), isLts)
 import Stackage.Snapshot.Diff
 
 getStackageHomeR :: SnapName -> Handler TypedContent

--- a/src/Handler/StackageSdist.hs
+++ b/src/Handler/StackageSdist.hs
@@ -6,7 +6,6 @@ module Handler.StackageSdist
 
 import Import
 import Stackage.Database
-import Stackage.Database.Types (SnapshotPackageInfo(..))
 import Handler.Package (packagePage)
 
 handlePNVTarball :: PackageNameP -> VersionP -> Handler TypedContent

--- a/src/Import.hs
+++ b/src/Import.hs
@@ -3,19 +3,16 @@ module Import
     ( module Import
     ) where
 
-import Control.Monad.Trans.Class (lift)
 import ClassyPrelude.Yesod as Import hiding (getCurrentTime)
 import Foundation as Import
 import Settings as Import
 import Settings.StaticFiles as Import
 import Types as Import
 import Yesod.Auth as Import
-import Yesod.Core.Handler (getYesod)
 import Data.WebsiteContent as Import (WebsiteContent (..))
 import Data.Text.Read (decimal)
 import RIO.Time (diffUTCTime)
 --import qualified Prometheus as P
-import Stackage.Database (SnapName)
 import Stackage.Database.Types (ModuleListingInfo(..))
 import Formatting (format)
 import Formatting.Time (diff)

--- a/src/Stackage/Database/Github.hs
+++ b/src/Stackage/Database/Github.hs
@@ -15,6 +15,7 @@ import RIO.FilePath
 import RIO.Process
 import RIO.Time
 
+
 data GithubRepo = GithubRepo
     { grAccount :: !String
     , grName    :: !String
@@ -33,17 +34,22 @@ lastGitFileUpdate ::
        (MonadReader env m, HasLogFunc env, HasProcessContext env, MonadUnliftIO m)
     => FilePath -- ^ Root dir of the repository
     -> FilePath -- ^ Relative path of the file
-    -> m (Either String UTCTime)
+    -> m (Maybe UTCTime)
 lastGitFileUpdate gitDir filePath = do
     lastCommitTimestamps <- gitLog gitDir filePath ["-1", "--format=%cD"]
     parseGitDate rfc822DateFormat lastCommitTimestamps
   where
     parseGitDate fmt dates =
         case listToMaybe $ LBS8.lines dates of
-            Nothing -> return $ Left "Git log is empty for the file"
-            Just lbsDate ->
-                mapLeft (displayException :: SomeException -> String) <$>
-                try (parseTimeM False defaultTimeLocale fmt (LBS8.unpack lbsDate))
+            Nothing -> do
+                logError "Git log is empty for the file"
+                return Nothing
+            Just lbsDate -> do
+                let parseDateTime = parseTimeM False defaultTimeLocale fmt (LBS8.unpack lbsDate)
+                catchAny (Just <$> liftIO parseDateTime) $ \exc -> do
+                    logError $
+                        "Error parsing git commit date: " <> fromString (displayException exc)
+                    pure Nothing
 
 -- | Clone a repository locally. In case when repository is already present sync it up with
 -- remote. Returns the full path where repository was cloned into.

--- a/src/Stackage/Database/Github.hs
+++ b/src/Stackage/Database/Github.hs
@@ -4,6 +4,7 @@ module Stackage.Database.Github
     ( cloneOrUpdate
     , lastGitFileUpdate
     , getStackageContentDir
+    , getCoreCabalFilesDir
     , GithubRepo(..)
     ) where
 
@@ -72,3 +73,11 @@ getStackageContentDir ::
     -> m FilePath
 getStackageContentDir rootDir =
     cloneOrUpdate rootDir (GithubRepo "commercialhaskell" "stackage-content")
+
+-- | Use backup location with cabal files, hackage doesn't have all of them.
+getCoreCabalFilesDir ::
+       (MonadReader env m, HasLogFunc env, HasProcessContext env, MonadIO m)
+    => FilePath
+    -> m FilePath
+getCoreCabalFilesDir rootDir =
+    cloneOrUpdate rootDir (GithubRepo "commercialhaskell" "core-cabal-files")

--- a/src/Stackage/Database/Haddock.hs
+++ b/src/Stackage/Database/Haddock.hs
@@ -38,9 +38,7 @@ hToHtml =
         H.dt (go x) ++ H.dd (go y)
     go (DocCodeBlock x) = H.pre $ H.code $ go x
     go (DocHyperlink (Hyperlink url mlabel)) =
-        H.a H.! A.href (H.toValue url) $ toHtml label
-      where
-        label = fromMaybe url mlabel
+        H.a H.! A.href (H.toValue url) $ maybe (toHtml url) (toHtml . go) mlabel
     go (DocPic (Picture url mtitle)) =
         H.img H.! A.src (H.toValue url) H.! A.title (H.toValue $ fromMaybe mempty mtitle)
     go (DocAName s) = H.div H.! A.id (H.toValue s) $ mempty

--- a/src/Stackage/Database/PackageInfo.hs
+++ b/src/Stackage/Database/PackageInfo.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ViewPatterns #-}
 module Stackage.Database.PackageInfo
     ( PackageInfo(..)
     , Identifier(..)
@@ -14,10 +14,11 @@ module Stackage.Database.PackageInfo
     ) where
 
 import CMarkGFM
-import Data.Coerce
 import Data.Char (isSpace)
+import Data.Coerce
 import Data.Map.Merge.Strict as Map
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 import Distribution.Compiler (CompilerFlavor(GHC))
 import Distribution.Package (Dependency(..))
 import Distribution.PackageDescription (CondTree(..), Condition(..),
@@ -26,28 +27,29 @@ import Distribution.PackageDescription (CondTree(..), Condition(..),
                                         GenericPackageDescription, author,
                                         condExecutables, condLibrary,
                                         description, genPackageFlags, homepage,
-                                        license, maintainer,
-                                        packageDescription, synopsis)
+                                        license, maintainer, packageDescription,
+                                        synopsis)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription,
                                                runParseResult)
 import Distribution.Pretty (prettyShow)
 import Distribution.System (Arch(X86_64), OS(Linux))
 import Distribution.Types.CondTree (CondBranch(..))
 import Distribution.Types.Library (exposedModules)
+import Distribution.Types.PackageDescription (PackageDescription(package))
 import Distribution.Types.VersionRange (VersionRange, intersectVersionRanges,
                                         normaliseVersionRange, withinRange)
 import Distribution.Version (simplifyVersionRange)
-import qualified Data.Text.Encoding as T
 import RIO
 import qualified RIO.Map as Map
 import qualified RIO.Map.Unchecked as Map (mapKeysMonotonic)
 import Stackage.Database.Haddock (renderHaddock)
 import Stackage.Database.Types (Changelog(..), Readme(..))
 import Text.Blaze.Html (Html, preEscapedToHtml, toHtml)
-import Types (CompilerP(..), FlagNameP(..), ModuleNameP(..), PackageNameP(..),
-              SafeFilePath, VersionP(..), VersionRangeP(..), unSafeFilePath)
-import Yesod.Form.Fields (Textarea(..))
 import Text.Email.Validate
+import Types (CompilerP(..), FlagNameP(..), ModuleNameP(..), PackageIdentifierP,
+              PackageNameP(..), SafeFilePath, VersionP(..), VersionRangeP(..),
+              unSafeFilePath, dtDisplay)
+import Yesod.Form.Fields (Textarea(..))
 
 
 data PackageInfo = PackageInfo
@@ -79,7 +81,7 @@ toPackageInfo gpd mreadme mchangelog =
         , piHomepage =
               case T.strip $ T.pack $ homepage pd of
                   "" -> Nothing
-                  x -> Just x
+                  x  -> Just x
         , piLicenseName = T.pack $ prettyShow $ license pd
         }
   where
@@ -125,17 +127,23 @@ parseCabalBlob cabalBlob =
 
 parseCabalBlobMaybe ::
        (MonadIO m, MonadReader env m, HasLogFunc env)
-    => PackageNameP
+    => PackageIdentifierP
     -> ByteString
     -> m (Maybe GenericPackageDescription)
-parseCabalBlobMaybe packageName cabalBlob =
+parseCabalBlobMaybe pidp cabalBlob =
     case snd $ runParseResult $ parseGenericPackageDescription cabalBlob of
         Left err ->
             Nothing <$
             logError
-                ("Problem parsing cabal blob for '" <> display packageName <> "': " <>
-                 displayShow err)
-        Right pgd -> pure $ Just pgd
+                ("Problem parsing cabal blob for '" <> display pidp <> "': " <> displayShow err)
+        Right gpd -> do
+            let pid = package (packageDescription gpd)
+            unless (textDisplay (dtDisplay pid :: Utf8Builder) == textDisplay pidp) $
+                logError $
+                "Supplied package identifier: '" <> display pidp <>
+                "' does not match the one in cabal file: '" <>
+                dtDisplay pid
+            pure $ Just gpd
 
 getCheckCond ::
        CompilerP -> Map FlagName Bool -> GenericPackageDescription -> Condition ConfVar -> Bool

--- a/src/Stackage/Database/PackageInfo.hs
+++ b/src/Stackage/Database/PackageInfo.hs
@@ -18,8 +18,6 @@ import Data.Coerce
 import Data.Char (isSpace)
 import Data.Map.Merge.Strict as Map
 import qualified Data.Text as T
-import Data.Text.Encoding (decodeUtf8With)
-import Data.Text.Encoding.Error (lenientDecode)
 import Distribution.Compiler (CompilerFlavor(GHC))
 import Distribution.Package (Dependency(..))
 import Distribution.PackageDescription (CondTree(..), Condition(..),
@@ -172,7 +170,7 @@ getDeps checkCond = goTree
   where
     goTree (CondNode _data deps comps) =
         combineDeps $
-        map (\(Dependency name range) -> Map.singleton (PackageNameP name) range) deps ++
+        map (\(Dependency name range _) -> Map.singleton (PackageNameP name) range) deps ++
         map goComp comps
     goComp (CondBranch cond yes no)
         | checkCond cond = goTree yes

--- a/src/Stackage/Database/Query.hs
+++ b/src/Stackage/Database/Query.hs
@@ -72,10 +72,10 @@ import Database.Esqueleto
 import Database.Esqueleto.Internal.Language (FromPreprocess)
 import Database.Esqueleto.Internal.Sql
 import qualified Database.Persist as P
-import Pantry.Internal.Stackage (EntityField(..), PackageName, Unique(..),
+import Pantry.Internal.Stackage (EntityField(..), PackageName,
                                  Version, getBlobKey, getPackageNameById,
                                  getPackageNameId, getTreeForKey, getVersionId,
-                                 loadBlobById, mkSafeFilePath, treeCabal)
+                                 loadBlobById, mkSafeFilePath)
 import RIO hiding (on, (^.))
 import qualified RIO.Map as Map
 import qualified RIO.Set as Set
@@ -364,7 +364,7 @@ getPackageVersionForSnapshot snapshotId pname =
              pure (v ^. VersionVersion))
 
 getLatest ::
-       FromPreprocess SqlQuery SqlExpr SqlBackend t
+       FromPreprocess t
     => PackageNameP
     -> (t -> SqlExpr (Value SnapshotId))
     -> (t -> SqlQuery ())

--- a/src/Stackage/Database/Query.hs
+++ b/src/Stackage/Database/Query.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 module Stackage.Database.Query
     (
       -- * Snapshot

--- a/src/Stackage/Database/Query.hs
+++ b/src/Stackage/Database/Query.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Stackage.Database.Query
     (
@@ -52,13 +53,15 @@ module Stackage.Database.Query
     , getTreeForKey
     , treeCabal
     -- ** Stackage server
+    , CabalFileIds
+    , addCabalFile
+    , getCabalFileIds
     , addSnapshotPackage
     , getHackageCabalByRev0
     , getHackageCabalByKey
     , snapshotMarkUpdated
     , insertSnapshotName
     , markModuleHasDocs
-    , insertSnapshotPackageModules
     , insertDeps
     -- ** For Hoogle db creation
     , lastLtsNightly
@@ -71,11 +74,14 @@ import qualified Data.List as L
 import Database.Esqueleto
 import Database.Esqueleto.Internal.Language (FromPreprocess)
 import Database.Esqueleto.Internal.Sql
+import Distribution.Types.PackageId (PackageIdentifier(PackageIdentifier))
+import Distribution.PackageDescription (packageDescription)
+import Distribution.Types.PackageDescription (PackageDescription(package))
 import qualified Database.Persist as P
 import Pantry.Internal.Stackage (EntityField(..), PackageName,
                                  Version, getBlobKey, getPackageNameById,
                                  getPackageNameId, getTreeForKey, getVersionId,
-                                 loadBlobById, mkSafeFilePath)
+                                 loadBlobById, storeBlob, mkSafeFilePath)
 import RIO hiding (on, (^.))
 import qualified RIO.Map as Map
 import qualified RIO.Set as Set
@@ -776,6 +782,75 @@ insertDeps pid snapshotPackageId dependencies =
                     display dep
                 return $ Just dep
 
+data CabalFileIds = CabalFileIds
+    { cfiPackageNameId :: !PackageNameId
+    , cfiVersionId :: !VersionId
+    , cfiCabalBlobId :: !(Maybe BlobId)
+    , cfiModuleNameIds :: ![ModuleNameId]
+    }
+
+getCabalFileIds ::
+       HasLogFunc env
+    => BlobId
+    -> GenericPackageDescription
+    -> ReaderT SqlBackend (RIO env) CabalFileIds
+getCabalFileIds cabalBlobId gpd = do
+    let PackageIdentifier name ver = package (packageDescription gpd)
+    packageNameId <- getPackageNameId name
+    versionId <- getVersionId ver
+    moduleNameIds <- mapM insertModuleSafe (extractModuleNames gpd)
+    pure
+        CabalFileIds
+            { cfiPackageNameId = packageNameId
+            , cfiVersionId = versionId
+            , cfiCabalBlobId = Just cabalBlobId
+            , cfiModuleNameIds = moduleNameIds
+            }
+
+addCabalFile ::
+       HasLogFunc env
+    => PackageIdentifierP
+    -> ByteString
+    -> ReaderT SqlBackend (RIO env) (Maybe (GenericPackageDescription, CabalFileIds))
+addCabalFile pid cabalBlob = do
+    mgpd <- lift $ parseCabalBlobMaybe pid cabalBlob
+    forM mgpd $ \gpd -> do
+        (cabalBlobId, _) <- storeBlob cabalBlob
+        cabalIds <- getCabalFileIds cabalBlobId gpd
+        pure (gpd, cabalIds)
+
+getPackageIds ::
+       GenericPackageDescription
+    -> Either CabalFileIds (Entity Tree)
+    -> ReaderT SqlBackend (RIO env) (CabalFileIds, Maybe (TreeId, BlobId))
+getPackageIds gpd =
+    \case
+        Left cabalFileIds -> pure (cabalFileIds, Nothing)
+        Right (Entity treeId tree)
+            -- -- TODO: Remove Maybe from cfiCabalBlobId and
+            -- --       Generate cabal file from package.yaml:
+            -- case treeCabal tree of
+            --   Just cabalBlobId -> pure cabalBlobId
+            --   Nothing -> do
+            --     let rawMetaData = RawPackageMetadata {
+            --           rpmName = Just pname
+            --           , rpmVersion = Just pver
+            --           , rpmTreeKey = treeKey tree
+            --           }
+            --         rpli = ... get
+            --     generateHPack (RPLIArchive / RPLIRepo ..) treeId treeVersion tree
+            --     ...
+         -> do
+            moduleNameIds <- mapM insertModuleSafe (extractModuleNames gpd)
+            let cabalFileIds =
+                    CabalFileIds
+                        { cfiPackageNameId = treeName tree
+                        , cfiVersionId = treeVersion tree
+                        , cfiCabalBlobId = treeCabal tree
+                        , cfiModuleNameIds = moduleNameIds
+                        }
+            pure (cabalFileIds, Just (treeId, treeKey tree))
+
 -- TODO: Optimize, whenever package is already in one snapshot only create the modules and new
 -- SnapshotPackage
 addSnapshotPackage ::
@@ -783,30 +858,27 @@ addSnapshotPackage ::
     => SnapshotId
     -> CompilerP
     -> Origin
-    -> Maybe (Entity Tree)
+    -> Either CabalFileIds (Entity Tree)
     -> Maybe HackageCabalId
     -> Bool
     -> Map FlagNameP Bool
     -> PackageIdentifierP
     -> GenericPackageDescription
     -> ReaderT SqlBackend (RIO env) ()
-addSnapshotPackage snapshotId compiler origin mTree mHackageCabalId isHidden flags pid gpd = do
-    let PackageIdentifierP pname pver = pid
-        mTreeId = entityKey <$> mTree
-    packageNameId <-
-        maybe (getPackageNameId (unPackageNameP pname)) (pure . treeName . entityVal) mTree
-    versionId <- maybe (getVersionId (unVersionP pver)) (pure . treeVersion . entityVal) mTree
+addSnapshotPackage snapshotId compiler origin eCabalTree mHackageCabalId isHidden flags pid gpd = do
+    (CabalFileIds{..}, mTree) <- getPackageIds gpd eCabalTree
+    let mTreeId = fst <$> mTree
     mrevision <- maybe (pure Nothing) getHackageRevision mHackageCabalId
     mreadme <- fromMaybe (pure Nothing) $ getContentTreeEntryId <$> mTreeId <*> mreadmeQuery
     mchangelog <- fromMaybe (pure Nothing) $ getContentTreeEntryId <$> mTreeId <*> mchangelogQuery
     let snapshotPackage =
             SnapshotPackage
                 { snapshotPackageSnapshot = snapshotId
-                , snapshotPackagePackageName = packageNameId
-                , snapshotPackageVersion = versionId
+                , snapshotPackagePackageName = cfiPackageNameId
+                , snapshotPackageVersion = cfiVersionId
                 , snapshotPackageRevision = mrevision
-                , snapshotPackageCabal = treeCabal =<< entityVal <$> mTree
-                , snapshotPackageTreeBlob = treeKey . entityVal <$> mTree
+                , snapshotPackageCabal = cfiCabalBlobId
+                , snapshotPackageTreeBlob = snd <$> mTree
                 , snapshotPackageOrigin = origin
                 , snapshotPackageOriginUrl = "" -- TODO: add
                 , snapshotPackageSynopsis = getSynopsis gpd
@@ -831,7 +903,8 @@ addSnapshotPackage snapshotId compiler origin mTree mHackageCabalId isHidden fla
     forM_ msnapshotPackageId $ \snapshotPackageId -> do
         _ <- insertDeps pid snapshotPackageId (extractDependencies compiler flags gpd)
         -- TODO: collect all missing dependencies and make a report
-        insertSnapshotPackageModules snapshotPackageId (extractModuleNames gpd)
+        forM_ cfiModuleNameIds $ \modNameId -> do
+            void $ P.insertBy (SnapshotPackageModule snapshotPackageId modNameId False)
 
 getContentTreeEntryId ::
        TreeId
@@ -977,16 +1050,6 @@ getSnapshotPackageCabalBlob snapshotId pname =
             ((sp ^. SnapshotPackageSnapshot ==. val snapshotId) &&.
              (pn ^. PackageNameName ==. val pname))
         return (blob ^. BlobContents)
-
-
--- | Add all modules available for the package in a particular snapshot. Initially they are marked
--- as without available documentation.
-insertSnapshotPackageModules ::
-       SnapshotPackageId -> [ModuleNameP] -> ReaderT SqlBackend (RIO env) ()
-insertSnapshotPackageModules snapshotPackageId =
-    mapM_ $ \modName -> do
-        moduleId <- insertModuleSafe modName
-        void $ P.insertBy (SnapshotPackageModule snapshotPackageId moduleId False)
 
 -- | Idempotent and thread safe way of adding a new module.
 insertModuleSafe :: ModuleNameP -> ReaderT SqlBackend (RIO env) ModuleNameId

--- a/src/Stackage/Database/Schema.hs
+++ b/src/Stackage/Database/Schema.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
@@ -8,8 +9,10 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Stackage.Database.Schema
     ( -- * Database
       run

--- a/src/Stackage/Database/Schema.hs
+++ b/src/Stackage/Database/Schema.hs
@@ -50,7 +50,7 @@ import Database.Persist.Postgresql
 import Database.Persist.TH
 import Pantry (HasPantryConfig(..), Revision)
 import Pantry.Internal.Stackage as PS (BlobId, HackageCabalId, ModuleNameId,
-                                       PackageNameId, Tree(..), TreeEntry(..),
+                                       PackageNameId, Tree(..),
                                        TreeEntryId, TreeId, Unique(..),
                                        VersionId, unBlobKey)
 import Pantry.Internal.Stackage (PantryConfig(..), Storage(..))

--- a/src/Stackage/Database/Types.hs
+++ b/src/Stackage/Database/Types.hs
@@ -51,8 +51,7 @@ import qualified Data.Text as T
 import Data.Text.Read (decimal)
 import Network.AWS (Env, HasEnv(..))
 import Pantry (BlobKey(..), CabalFileInfo(..), FileSize(..),
-               HasPantryConfig(..), PackageIdentifierRevision(..), TreeKey(..))
-import Pantry.Internal.Stackage as Pantry (PantryConfig)
+               HasPantryConfig(..), PantryConfig, PackageIdentifierRevision(..), TreeKey(..))
 import Pantry.SHA256 (fromHexText)
 import RIO
 import RIO.Process (HasProcessContext(..), ProcessContext)

--- a/src/Stackage/Database/Types.hs
+++ b/src/Stackage/Database/Types.hs
@@ -52,8 +52,7 @@ import Data.Text.Read (decimal)
 import Network.AWS (Env, HasEnv(..))
 import Pantry (BlobKey(..), CabalFileInfo(..), FileSize(..),
                HasPantryConfig(..), PackageIdentifierRevision(..), TreeKey(..))
-import Pantry.Internal.Stackage as Pantry (PackageNameP(..), PantryConfig,
-                                           VersionP(..))
+import Pantry.Internal.Stackage as Pantry (PantryConfig)
 import Pantry.SHA256 (fromHexText)
 import RIO
 import RIO.Process (HasProcessContext(..), ProcessContext)

--- a/src/Stackage/Snapshot/Diff.hs
+++ b/src/Stackage/Snapshot/Diff.hs
@@ -22,7 +22,7 @@ import Data.These
 import RIO
 import Stackage.Database (GetStackageDatabase, SnapshotId,
                           getPackagesForSnapshot)
-import Stackage.Database.Types (PackageListingInfo(..), SnapName)
+import Stackage.Database.Types (PackageListingInfo(..))
 import Types
 import Web.PathPieces
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -61,18 +61,16 @@ import Database.Persist
 import Database.Persist.Sql (PersistFieldSql(sqlType))
 import qualified Distribution.ModuleName as DT (components, fromComponents,
                                                 validModuleComponent)
-import Distribution.PackageDescription (FlagName, GenericPackageDescription)
+import Distribution.PackageDescription (GenericPackageDescription)
 import Distribution.Parsec as DT (Parsec)
 import Distribution.Pretty as DT (Pretty)
 import qualified Distribution.Text as DT (display, simpleParse)
 import Distribution.Types.VersionRange (VersionRange)
 import Distribution.Version (mkVersion, versionNumbers)
-import Pantry (Revision(..))
+import Pantry (FlagName, Revision(..), packageNameString, parsePackageName,
+               parseVersionThrowing, parseVersion, versionString)
 import Pantry.Internal.Stackage (ModuleNameP(..), PackageNameP(..),
-                                 SafeFilePath, VersionP(..), packageNameString,
-                                 parsePackageName, parseVersion,
-                                 parseVersionThrowing, unSafeFilePath,
-                                 versionString)
+                                 SafeFilePath, VersionP(..), unSafeFilePath)
 import RIO
 import qualified RIO.Map as Map
 import RIO.Time (Day)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -49,7 +49,6 @@ module Types
     ) where
 
 import ClassyPrelude.Yesod (ToBuilder(..))
-import Control.Monad.Catch (MonadThrow, throwM)
 import Data.Aeson
 import Data.Bifunctor (bimap)
 import Data.Char (ord)
@@ -63,7 +62,9 @@ import Database.Persist.Sql (PersistFieldSql(sqlType))
 import qualified Distribution.ModuleName as DT (components, fromComponents,
                                                 validModuleComponent)
 import Distribution.PackageDescription (FlagName, GenericPackageDescription)
-import qualified Distribution.Text as DT (Text, display, simpleParse)
+import Distribution.Parsec as DT (Parsec)
+import Distribution.Pretty as DT (Pretty)
+import qualified Distribution.Text as DT (display, simpleParse)
 import Distribution.Types.VersionRange (VersionRange)
 import Distribution.Version (mkVersion, versionNumbers)
 import Pantry (Revision(..))
@@ -84,14 +85,14 @@ instance Exception ParseFailedException where
     displayException (ParseFailedException tyRep origString) =
         "Was unable to parse " ++ showsTypeRep tyRep ": " ++ origString
 
-dtParse :: forall a m. (Typeable a, DT.Text a, MonadThrow m) => Text -> m a
+dtParse :: forall a m. (Typeable a, DT.Parsec a, MonadThrow m) => Text -> m a
 dtParse txt =
     let str = T.unpack txt
      in case DT.simpleParse str of
             Nothing -> throwM $ ParseFailedException (typeRep (Proxy :: Proxy a)) str
             Just dt -> pure dt
 
-dtDisplay :: (DT.Text a, IsString b) => a -> b
+dtDisplay :: (DT.Pretty a, IsString b) => a -> b
 dtDisplay = fromString . DT.display
 
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ extra-deps:
 - yesod-gitrepo-0.3.0@sha256:7aad996935065726ce615c395d735cc01dcef3993b1788f670f6bfc866085e02,1191
 - lukko-0.1.1.1@sha256:5c674bdd8a06b926ba55d872abe254155ed49a58df202b4d842b643e5ed6bcc9,4289
 - github: commercialhaskell/pantry
-  commit: 86462a97c4d8091993cc6e246fd0f2ae5aa608f0
+  commit: ed48bebc30e539280ad7e13680480be2b87b97ea
 - github: fpco/casa
   commit: fc0ed26858bfc4f2966ed2dfb2871bae9266dda6
   subdirs:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,17 @@
-resolver: lts-13.16
+resolver: nightly-2020-02-08
 packages:
   - '.'
 extra-deps:
-- git: https://github.com/commercialhaskell/stack
-  commit: dfbf85ad7e8af5b01cf7b51367290870ffc2c90e
+- barrier-0.1.1@sha256:2021f84c3aba67bb635d72825d3bc0371942444dc014bc307b875071e29eea98,3931
+- hackage-security-0.6.0.0@sha256:69987d46e7b55fe5f0fc537021c3873c5f6f44a6665d349ee6995fd593df8147,11976
+- hoogle-5.0.17.14@sha256:a35eab4f833cd131f1abc79360e3bdbc5aecd7526b9a530ac606580e18691e2b,3173
+- hpack-0.33.0@sha256:ca82f630abe0fba199aa05dcc9942ee8bf137e1425049a7a9ac8458c82d9dcc9,4406
+- yesod-gitrepo-0.3.0@sha256:7aad996935065726ce615c395d735cc01dcef3993b1788f670f6bfc866085e02,1191
+- lukko-0.1.1.1@sha256:5c674bdd8a06b926ba55d872abe254155ed49a58df202b4d842b643e5ed6bcc9,4289
+- github: commercialhaskell/pantry
+  commit: 86462a97c4d8091993cc6e246fd0f2ae5aa608f0
+- github: fpco/casa
+  commit: fc0ed26858bfc4f2966ed2dfb2871bae9266dda6
   subdirs:
-  - subs/http-download
-  - subs/pantry
-  - subs/rio-prettyprint
+     - casa-client
+     - casa-types


### PR DESCRIPTION
Use [commercialhaskell/core-cabal-files](https://github.com/commercialhaskell/core-cabal-files) repository as a fallback for core packages that are missing from Hackage. Here is a sample [`base-4.13.0.0`](https://lehins.net/nightly-2020-02-06/package/base-4.13.0.0) page

This also fixes "Depends on" count on each package page being one off, since now it will list `base` as well.

In order to get it fixed few things were required:

* Update to pantry-0.2.0.0 that supports Cabal-3.x which is great, cause now we can have cabal files with new syntax on stackage.org
* Update to nightly lts with ghc-8.8, since some dependencies were not happy about Cabal-3.x
* Ability to store fallback cabal files in pantry.

This PR depends on: commercialhaskell/pantry#15