### PR TITLE
Record available hoogle db files per snapshot + hoogle version

### DIFF
--- a/src/Handler/Home.hs
+++ b/src/Handler/Home.hs
@@ -36,6 +36,7 @@ getHomeR = track "Handler.Snapshots.getAllSnapshotsR" $ do
         getSnapshots Nothing snapshotsPerPage
                              ((fromIntegral currentPage - 1) * snapshotsPerPage)
     let groups = groupUp now' snapshots
+    latestLtsNameWithHoogle <- getLatestLtsNameWithHoogle
     latestLtsByGhc <- getLatestLtsByGhc
     defaultLayout $ do
         setTitle "Stackage Server"

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -17,7 +17,7 @@ import Data.Yaml.Config
 import Language.Haskell.TH.Syntax (Exp, Name, Q)
 import Network.Wai.Handler.Warp (HostPreference)
 import Text.Hamlet
-import Yesod.Default.Config2 (applyEnvValue, configSettingsYml)
+import Yesod.Default.Config2 (configSettingsYml)
 import Yesod.Default.Util (WidgetFileSettings, wfsHamletSettings,
                            widgetFileNoReload, widgetFileReload)
 

--- a/src/Stackage/Database/Types.hs
+++ b/src/Stackage/Database/Types.hs
@@ -88,6 +88,7 @@ data StackageCron = StackageCron
     , scSnapshotsRepo      :: !GithubRepo
     , scReportProgress     :: !Bool
     , scCacheCabalFiles    :: !Bool
+    , scHoogleVersionId    :: !VersionId
     }
 
 instance HasEnv StackageCron where

--- a/templates/home.hamlet
+++ b/templates/home.hamlet
@@ -3,7 +3,7 @@
         <div .span6>
             <img src=@{StaticR img_logo_png} .logo>
         <div .span6>
-            <form class="hoogle" action="/lts/hoogle">
+            <form class="hoogle" action="/#{latestLtsNameWithHoogle}/hoogle">
               <div class="input-append hoogle-q">
                 <input class="search span3" type="search" autofocus="" name="q" value="" placeholder="E.g. map, a -> a, etc.">
                 <button class="btn" type="submit">


### PR DESCRIPTION
This PR mainly solves the problem of long delays before hoogle db can appear after a hoogle update, but it does even more than that:

* There is now a record of each generated hoogle version db for each snapshot, which means:
  * even upon an upgrade we can easily downgrade hoogle version with no intervention
  * we can now over time generate hoogle db for all snapshots.

* At each iteration of a cron job only 5 latest lts snapshots and 5 latest nightly snapshots that don't have current hoogle db generated, will get a new one generated for each of them. 

* If a snapshot previously had a hoogle db generated and it is available on S3, it will not be regenerated, but simply marked as available.

* Earlier two points mean that there is never duplicate generation of the same hoogle-version + snapshot combination. Even in a case of such disaster as loss of database, we can recover with minimal effort

* A bonus point goes to the home page hoogle search form, which will now always point at a latest lts snapshot with hoogle db available, which means there is not gonna be a period of time that the search is not available during a cron update (when snapshot is available, but hoogle db hasn't been generated yet)