### PR TITLE
Increase memory limitation for stackage-server-cron

### DIFF
--- a/etc/helm/values/staging.yaml
+++ b/etc/helm/values/staging.yaml
@@ -28,9 +28,9 @@ cronResources:
   resources:
     requests:
       cpu: 150m
-      memory: 1048Mi
+      memory: 2Gi
     limits:
      cpu: 200m
-     memory: 2096Mi
+     memory: 4Gi
 
 registrySecretName: registry-key


### PR DESCRIPTION
During process with hoogle, the memory usage excceeds 2GiB and causes pod crashing loop.