### PR TITLE
a few fixups

### DIFF
--- a/src/Handler/Home.hs
+++ b/src/Handler/Home.hs
@@ -33,9 +33,6 @@ getHomeR = track "Handler.Snapshots.getAllSnapshotsR" $ do
     (map entityVal -> nightly) <-
         getSnapshots (Just  NightlyBranch) 1 0
     let latestNightly = groupUp now' nightly
-    (map entityVal -> lts) <-
-        getSnapshots (Just  LtsBranch) 1 0
-    let latestLts = groupUp now' lts
     latestLtsNameWithHoogle <- getLatestLtsNameWithHoogle
     latestLtsByGhc <- getLatestLtsByGhc
 

--- a/templates/default-layout.hamlet
+++ b/templates/default-layout.hamlet
@@ -10,9 +10,9 @@
       <div class="nav-collapse collapse">
         <ul class="nav">
             <li> <a href="/#about">About</a>
+            <li> <a href="/snapshots">Snapshots</a>
             <li> <a href="/lts">LTS</a>
             <li> <a href="/nightly">Nightly</a>
-            <li> <a href="/snapshots">Snapshots</a>
             <li> <a href="https://github.com/fpco/stackage#frequently-asked-questions">FAQ</a>
             <li> <a href="/blog">Blog</a>
 

--- a/templates/home.hamlet
+++ b/templates/home.hamlet
@@ -21,25 +21,18 @@
               <li><a href="https://haskellstack.org">stack</a> makes using Stackage easy
         <div .span6>
             <h3>News</h3>
-              <ul .snapshots>
-              $forall stackages <- latestNightly
-                  $forall (ident, title, uploaded) <- stackages
-                      <li>
-                          <strong>
-                              <a href=@{SnapshotR ident StackageHomeR}>#{title}</a>, #{uploaded}
-              $forall stackages <- latestLts
-                  $forall (ident, title, uploaded) <- stackages
-                      <li>
-                          <strong>
-                              <a href=@{SnapshotR ident StackageHomeR}>#{title}</a>, #{uploaded}
               $maybe post <- mrecentBlog
                 <p>
                   <a href=@{BlogPostR (postYear post) (postMonth post) (postSlug post)}>#{postTitle post}</a>,
                   <abbr title=#{show $ postTime post}>#{dateDiff now' (utctDay $ postTime post)}</abbr>
         <div .span6>
             <h3>
-                Latest LTS release per GHC version
+                Latest releases per GHC version
             <ul>
+                $forall stackages <- latestNightly
+                 $forall (ident, title, uploaded) <- stackages
+                  <li>
+                    <a href=@{SnapshotR ident StackageHomeR}>#{title}</a>, #{uploaded}
                 $forall (major, minor, ghc, date) <- latestLtsByGhc
                   <li>
                     <a href=@{SnapshotR (SNLts major minor) StackageHomeR}>LTS #{major}.#{minor} for #{ghc}#

--- a/templates/snapshots-nav.hamlet
+++ b/templates/snapshots-nav.hamlet
@@ -7,4 +7,4 @@
   $if not isLastPage
     <span .separator>
     <a href=@{AllSnapshotsR}?page=#{currentPage + 1}>
-      older \>
+      older >


### PR DESCRIPTION
The main change here is to move recent snapshots from News into the Releases per ghc section.
(I haven't verified the rendering)

- Also move Snapshots left on the Navbar
- Remove \ before > on /snapshots