### PR TITLE
Attempt to fix slow queries

### DIFF
--- a/bench/main.hs
+++ b/bench/main.hs
@@ -36,8 +36,8 @@ runBenchApp pool m = runSimpleApp $ runSqlPool m pool
 createBenchPool :: IO ConnectionPool
 createBenchPool = do
     loadYamlSettingsArgs [configSettingsYmlValue] useEnv >>= \case
-        AppSettings{appDatabase = DSPostgres pgString pgPoolSize} ->
-            runNoLoggingT $ createPostgresqlPool (encodeUtf8 pgString) pgPoolSize
+        AppSettings{appDatabase = DSPostgres pgString _} ->
+            runNoLoggingT $ createPostgresqlPool (encodeUtf8 pgString) 1
         _ -> throwString "Benchmarks are crafted for PostgreSQL"
 
 releasePool :: ConnectionPool -> IO ()

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -56,7 +56,7 @@ data AppSettings = AppSettings
     }
 
 data DatabaseSettings
-    = DSPostgres !Text !Int
+    = DSPostgres !Text !(Maybe Int)
     | DSSqlite !Text !Int
 
 parseDatabase


### PR DESCRIPTION
I was able to reproduce slowness locally and despite what gauge benchmarks say this new approach taken in `getSnapshotPackageLatestVersionQuery`  becomes faster. It is a bit surprising, but maybe worth a try.

This PR also includes an extra helpful functionality for inferring PG pool size from number of capabilities.

