### PR TITLE
Attempt to fix slow queries

### DIFF
--- a/bench/main.hs
+++ b/bench/main.hs
@@ -36,8 +36,8 @@ runBenchApp pool m = runSimpleApp $ runSqlPool m pool
 createBenchPool :: IO ConnectionPool
 createBenchPool = do
     loadYamlSettingsArgs [configSettingsYmlValue] useEnv >>= \case
-        AppSettings{appDatabase = DSPostgres pgString pgPoolSize} ->
-            runNoLoggingT $ createPostgresqlPool (encodeUtf8 pgString) pgPoolSize
+        AppSettings{appDatabase = DSPostgres pgString _} ->
+            runNoLoggingT $ createPostgresqlPool (encodeUtf8 pgString) 1
         _ -> throwString "Benchmarks are crafted for PostgreSQL"
 
 releasePool :: ConnectionPool -> IO ()

--- a/indices
+++ b/indices
@@ -1,2 +1,3 @@
 create index nightly_snap on nightly(snap);
 create index snapshot_package_snapshot on snapshot_package(snapshot);
+create index snapshot_created on snapshot (created desc);

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -56,7 +56,7 @@ data AppSettings = AppSettings
     }
 
 data DatabaseSettings
-    = DSPostgres !Text !Int
+    = DSPostgres !Text !(Maybe Int)
     | DSSqlite !Text !Int
 
 parseDatabase


### PR DESCRIPTION
Looks like it's impossible to reopen PR after a force push, so here is a new one instead of #302 

This one definitely improves things quite a bit. Trick is in the index on sorting on lts creation date.

I could never replicate it locally because it turns database/hdd cache was always kicking in on subsequent queries, so I would never notice stackage.org/package/packagename page to be that slow until today. That's why benchmarks of the query also run incredibly fast, because a query that is being benchmarked doesn't change.