### PR TITLE
hide News if no recent blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-stackage-server
-===============
+# stackage-server
 
 ![Runtime image](https://github.com/fpco/stackage-server/workflows/Runtime%20image/badge.svg)
 
@@ -16,6 +15,13 @@ Build locally by passing the `dev` flag to it:
 $ stack build . --flag stackage-server:dev
 ```
 
+## Simple testing with sqlite:
+To test the UI without real data, just run:
+```
+$ yesod devel
+```
+
+## Testing with postgresql
 Now, initially you need to run the cron job to create and populate the database:
 
 ``` shellsession

--- a/src/Handler/Home.hs
+++ b/src/Handler/Home.hs
@@ -35,8 +35,8 @@ getHomeR = track "Handler.Snapshots.getAllSnapshotsR" $ do
     let latestNightly = groupUp now' nightly
     latestLtsNameWithHoogle <- getLatestLtsNameWithHoogle
     latestLtsByGhc <- getLatestLtsByGhc
-
-    mrecentBlog <- headMay <$> getPosts
+    let sixMonthsAgo = addUTCTime (-180 * nominalDay) now'
+    mrecentBlog <- headMay . filter (\p -> postTime p > sixMonthsAgo) <$> getPosts
 
     defaultLayout $ do
         setTitle "Stackage Server"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.20
+resolver: lts-16.31
 extra-deps:
 - barrier-0.1.1@sha256:2021f84c3aba67bb635d72825d3bc0371942444dc014bc307b875071e29eea98,3931
 - hackage-security-0.6.0.1

--- a/templates/home.hamlet
+++ b/templates/home.hamlet
@@ -20,8 +20,8 @@
               <li>Stackage is a community project: <a href="https://github.com/fpco/stackage/blob/master/MAINTAINERS.md#adding-a-package"><b>how to add packages to Stackage</b></a>
               <li><a href="https://haskellstack.org">stack</a> makes using Stackage easy
         <div .span6>
-            <h3>News</h3>
-              $maybe post <- mrecentBlog
+            $maybe post <- mrecentBlog
+              <h3>News</h3>
                 <p>
                   <a href=@{BlogPostR (postYear post) (postMonth post) (postSlug post)}>#{postTitle post}</a>,
                   <abbr title=#{show $ postTime post}>#{dateDiff now' (utctDay $ postTime post)}</abbr>


### PR DESCRIPTION
I bundled a few minor tweaks in here:

- lts-16.31
- mention `yesod devel` in Readme
- only show News if blog post is from last 6 years

(alternative solutions might include blogging more or putting News later if out of date,
but I think this change makes sense - untested with data though).