### PR TITLE
replace snapshot pages' resolver help with direct link to the stack doc

### DIFF
--- a/templates/stackage-home.hamlet
+++ b/templates/stackage-home.hamlet
@@ -8,10 +8,7 @@ $newline never
         <span>
             <a href=@{StackageDiffR previousSnapName name}>View changes
 
-    <p>To use this resolver, edit your stack.yaml and set the following:
-      <p .stack-resolver-yaml>resolver: #{toPathPiece name}
-    <p>or on the command line you can use: <code>stack --resolver #{toPathPiece name} ...</code>
-    <p>For more details see <a href="http://docs.haskellstack.org">the stack homepage</a>
+    <p .stack-resolver-yaml><a href="https://docs.haskellstack.org/en/stable/GUIDE/#resolvers-and-changing-your-compiler-version">resolver</a>: #{toPathPiece name}
 
     <h3>Hoogle
     ^{hoogleForm}


### PR DESCRIPTION
This is to simplify the top of snapshot pages.
I think by now for most people (myself at least) the resolver help text is mostly "invisible".
So feel it is better just to show the resolver with a link to the stack documentation on resolvers.

This seems more concise and compact: newcomers should read the docs to understand it properly anyway.

NB This builds but I haven't actually seen the result yet since `yesod devel` doesn't create any dummy snapshots,
but it should look something like this:

**[resolver](https://docs.haskellstack.org/en/stable/GUIDE/#resolvers-and-changing-your-compiler-version): lts-17.15**