### PR TITLE
remove the <h3>Hoogle before the hoogle search box

### DIFF
--- a/templates/stackage-home.hamlet
+++ b/templates/stackage-home.hamlet
@@ -10,7 +10,6 @@ $newline never
 
     <p .stack-resolver-yaml><a href="https://docs.haskellstack.org/en/stable/GUIDE/#resolvers-and-changing-your-compiler-version">resolver</a>: #{toPathPiece name}
 
-    <h3>Hoogle
     ^{hoogleForm}
 
     <h3>Packages (#{packageCount})


### PR DESCRIPTION
One more small tweak to snapshot pages: drop the `<h3>Hoogle` section header.

I don't think it is really necessary