### PR TITLE
Compatibility with newer dependencies

### DIFF
--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -11,6 +11,9 @@ module Settings where
 
 import ClassyPrelude.Yesod
 import Data.Aeson (Result(..), fromJSON, withObject, (.!=), (.:?))
+#if MIN_VERSION_aeson(2,0,0)
+import Data.Aeson.KeyMap (KeyMap)
+#endif
 import Data.FileEmbed (embedFile)
 import Data.Yaml (decodeEither', Parser)
 import Data.Yaml.Config
@@ -61,7 +64,11 @@ data DatabaseSettings
 
 parseDatabase
   :: Bool -- ^ is this dev? if so, allow default of SQLite
+#if MIN_VERSION_aeson(2,0,0)
+  -> KeyMap Value
+#else
   -> HashMap Text Value
+#endif
   -> Parser DatabaseSettings
 parseDatabase isDev o =
     if isDev

--- a/src/Stackage/Database/Haddock.hs
+++ b/src/Stackage/Database/Haddock.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 module Stackage.Database.Haddock
     ( renderHaddock
@@ -8,6 +9,9 @@ import qualified Documentation.Haddock.Parser as Haddock
 import Documentation.Haddock.Types (DocH(..), Example(..), Header(..),
                                     Hyperlink(..), MetaDoc(..), Picture(..),
                                     Table(..), TableCell(..), TableRow(..))
+#if MIN_VERSION_haddock_library(1,10,0)
+import Documentation.Haddock.Types (ModLink(modLinkName))
+#endif
 import Text.Blaze.Html (Html, toHtml)
 import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
@@ -27,13 +31,21 @@ hToHtml =
     go (DocParagraph x) = H.p $ go x
     go (DocIdentifier s) = H.code $ toHtml s
     go (DocIdentifierUnchecked s) = H.code $ toHtml s
+#if MIN_VERSION_haddock_library(1,10,0)
+    go (DocModule modLink) = H.code $ toHtml $ modLinkName modLink
+#else
     go (DocModule s) = H.code $ toHtml s
+#endif
     go (DocWarning x) = H.span H.! A.class_ "warning" $ go x
     go (DocEmphasis x) = H.em $ go x
     go (DocMonospaced x) = H.code $ go x
     go (DocBold x) = H.strong $ go x
     go (DocUnorderedList xs) = H.ul $ foldMap (H.li . go) xs
+#if MIN_VERSION_haddock_library(1,11,0)
+    go (DocOrderedList xs) = H.ol $ foldMap (H.li . go . snd) xs
+#else
     go (DocOrderedList xs) = H.ol $ foldMap (H.li . go) xs
+#endif
     go (DocDefList xs) = H.dl $ flip foldMap xs $ \(x, y) ->
         H.dt (go x) ++ H.dd (go y)
     go (DocCodeBlock x) = H.pre $ H.code $ go x


### PR DESCRIPTION
This isn't improving compatibility with amazonka-2.0 (which still hasn't been released to Hackage), or with esqueleto-3.5, but I thought it was a start.

Not sure whether CPP is the right approach since this application only really is deployed in a single instance, but I thought I'd share it.
