### PR TITLE
fix(opensearch): search url protocol: `http` -> `https`

### DIFF
--- a/static/opensearchhoogle.xml
+++ b/static/opensearchhoogle.xml
@@ -8,8 +8,8 @@
     <Language>en-us</Language>
     <InputEncoding>UTF-8</InputEncoding>
     <OutputEncoding>UTF-8</OutputEncoding>
-    <Image width="222" height="222" type="image/x-icon">http://www.stackage.org/static/img/stackage.png</Image>
-    <Url type="text/html" method="GET" template="http://www.stackage.org/lts/hoogle?q={searchTerms}"/>
+    <Image width="222" height="222" type="image/x-icon">https://www.stackage.org/static/img/stackage.png</Image>
+    <Url type="text/html" method="GET" template="https://www.stackage.org/lts/hoogle?q={searchTerms}"/>
     <Query role="example" searchTerms="E.g. map, a -> a"/>
-    <moz:SearchForm>http://www.stackage.org</moz:SearchForm>
+    <moz:SearchForm>https://www.stackage.org</moz:SearchForm>
 </OpenSearchDescription>

--- a/static/opensearchpackage.xml
+++ b/static/opensearchpackage.xml
@@ -8,8 +8,8 @@
     <Language>en-us</Language>
     <InputEncoding>UTF-8</InputEncoding>
     <OutputEncoding>UTF-8</OutputEncoding>
-    <Image width="222" height="222" type="image/x-icon">http://www.stackage.org/static/img/stackage.png</Image>
-    <Url type="text/html" method="GET" template="http://www.stackage.org/package/{searchTerms}"/>
+    <Image width="222" height="222" type="image/x-icon">https://www.stackage.org/static/img/stackage.png</Image>
+    <Url type="text/html" method="GET" template="https://www.stackage.org/package/{searchTerms}"/>
     <Query role="example" searchTerms="E.g. bytestring"/>
-    <moz:SearchForm>http://www.stackage.org</moz:SearchForm>
+    <moz:SearchForm>https://www.stackage.org</moz:SearchForm>
 </OpenSearchDescription>


### PR DESCRIPTION
Changed the protocol of the URL used as a custom search engine from `http` to `https`.

The reason for this change is that `www.stackage.org` only uses `https`, so every time the custom search engine is used,
a redirect from `http` to `https` occurs,
sacrificing the cleanliness of the history.

On `www.stackage.org`,
the HTTP header is set to
`strict-transport-security max-age=15724800; includeSubDomains` for HSTS,
so there's no need to try connecting via http.

This is a bit unclear to me as well,
but even though HSTS is set and a redirect is set for subsequent access, it seems that no communication is being made,
but it is left in the history.

In any case,
I think it's wasteful to constantly access http when it's specialized for https to the point of setting HSTS,
so I'm making this commit.