### PR TITLE
add a cabal.config link to snapshot pages

### DIFF
--- a/templates/stackage-home.hamlet
+++ b/templates/stackage-home.hamlet
@@ -8,7 +8,7 @@ $newline never
         <span>
             <a href=@{StackageDiffR previousSnapName name}>View changes
 
-    <p .stack-resolver-yaml><a href="https://docs.haskellstack.org/en/stable/GUIDE/#resolvers-and-changing-your-compiler-version">resolver</a>: #{toPathPiece name}
+    <p .stack-resolver-yaml><a href="https://docs.haskellstack.org/en/stable/GUIDE/#resolvers-and-changing-your-compiler-version">resolver</a>: #{toPathPiece name} (<a href="cabal.config">cabal.config</a>)
 
     ^{hoogleForm}
 


### PR DESCRIPTION
The PR adds a link to the `cabal.config` file for a stackage snapshot to its page.

This makes it more obvious for cabal-install users.