### PR TITLE
Revert "Force using only latest Hoogle DBs"

### DIFF
--- a/src/Handler/Hoogle.hs
+++ b/src/Handler/Hoogle.hs
@@ -23,12 +23,7 @@ getHoogleDB name = track "Handler.Hoogle.getHoogleDB" do
     liftIO $ appGetHoogleDB app name
 
 getHoogleR :: SnapName -> Handler Html
-getHoogleR name0 = track "Handler.Hoogle.getHoogleR" do
-    let branch =
-          case name0 of
-            SNLts _ _ -> LtsBranch
-            SNNightly _ -> NightlyBranch
-    name <- newestSnapshot branch >>= maybe notFound return
+getHoogleR name = track "Handler.Hoogle.getHoogleR" do
     Entity _ snapshot <- lookupSnapshot name >>= maybe notFound return
     mquery <- lookupGetParam "q"
     mPackageName <- lookupGetParam "package"


### PR DESCRIPTION
related to #326

This reverts commit 68fa14a4bb5303fc1b4bffea7643c469c6894c02.

i haven't reverted the log line that was added as it seemed unrelated to the actual commit description