### PR TITLE
Use `snapshot` instead of `resolver`

### DIFF
--- a/src/Stackage/Database/Cron.hs
+++ b/src/Stackage/Database/Cron.hs
@@ -424,7 +424,7 @@ addPantryPackage snapId compiler isHidden flags (PantryPackage pcabal pTreeKey) 
 
 
 
--- | Download a list of available .html files from S3 bucket for a particular resolver and record
+-- | Download a list of available .html files from S3 bucket for a particular snapshot and record
 -- in the database which modules have documentation available for them.
 checkForDocs :: SnapshotId -> SnapName -> ResourceT (RIO StackageCron) ()
 checkForDocs snapshotId snapName = do

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # As this is built on NixOS stable, it has to stay on a GHC that exists on the
 # OS.
 # I.e. changes here need to be synced with changes to flake.nix and package.nix.
-resolver: lts-24.26
+snapshot: lts-24.26
 extra-deps:
 # WARNING: Changing the hoogle version causes stackage-server-cron to regenerate
 # Hoogle databases FOR EVERY SNAPSHOT, EVER. Usually, that's ok! But don't

--- a/templates/stackage-home.hamlet
+++ b/templates/stackage-home.hamlet
@@ -8,7 +8,7 @@ $newline never
         <span>
             <a href=@{StackageDiffR previousSnapName name}>View changes
 
-    <p .stack-resolver-yaml><a href="https://docs.haskellstack.org/en/stable/GUIDE/#resolvers-and-changing-your-compiler-version">resolver</a>: #{toPathPiece name}
+    <p .stack-snapshot-yaml><a href="https://docs.haskellstack.org/en/stable/tutorial/building_your_project/#snapshots-and-ghc-versions">snapshot</a>: #{toPathPiece name}
 
     ^{hoogleForm}
 

--- a/templates/stackage-home.lucius
+++ b/templates/stackage-home.lucius
@@ -79,7 +79,7 @@ p + ul {
 .keyword { color: #366354 }
 .url { color: #06537d }
 
-.stack-resolver-yaml {
+.stack-snapshot-yaml {
     font-size: 1.3em;
     font-weight: 600;
 }


### PR DESCRIPTION
This fixes https://github.com/commercialhaskell/stackage-server/issues/334.

There is one last "resolver" [remnant](https://github.com/commercialhaskell/stackage-server/blob/cf71b274a35e0fa80a6b32e3dc764e90f117fae2/src/Stackage/Database/Types.hs#L195) that cannot be changed to "snapshot" because [stackage-snapshots](https://github.com/commercialhaskell/stackage-snapshots/) still use the `resolver` field.
